### PR TITLE
job.GetConfig() gets a 400 Bad request from Jenkins

### DIFF
--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -25,6 +25,14 @@ var paths = map[string]func(http.ResponseWriter, *http.Request){
 			fmt.Fprintln(rw, readJson("job1.json"))
 		}
 	},
+	"/job/testJob/config.xml/api/json": func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method == "GET" {
+			fmt.Fprintln(rw, readJson("job.xml"))
+		} else {
+			rw.WriteHeader(400)
+			fmt.Fprintln(rw, "Bad request")
+		}
+	},
 	"/job/testJob/1/api/json":     func(rw http.ResponseWriter, req *http.Request) { fmt.Fprintln(rw, readJson("job1_build1.json")) },
 	"/job/testJob/2/api/json":     func(rw http.ResponseWriter, req *http.Request) { fmt.Fprintln(rw, readJson("job1_build1.json")) },
 	"/job/testJob/3/api/json":     func(rw http.ResponseWriter, req *http.Request) { fmt.Fprintln(rw, readJson("job1_build1.json")) },
@@ -82,6 +90,7 @@ func TestBuildMethods(t *testing.T) {
 func TestGetSingleJob(t *testing.T) {
 	job := jenkins.GetJob("testJob")
 	assert.Equal(t, false, job.IsRunning())
+	assert.Contains(t, job.GetConfig(), "<project>")
 	// TODO: All Methods
 }
 


### PR DESCRIPTION
Hi, My Jenkins box is returning a 400 Bad request when grabbing the job config.xml with `job.GetConfig()`

It appears to set the HTTP method to XML which causes Jenkins to complain.

I think this patch should fix it but I'm a go novice. Shout if you want me to make any changes, appreciate any advice

Thanks