### PR TITLE
Add missing double-quote in json tag for Runs

### DIFF
--- a/build.go
+++ b/build.go
@@ -151,7 +151,7 @@ type buildResponse struct {
 	Runs              []struct {
 		Number int64
 		Url    string
-	} `json:"runs`
+	} `json:"runs"`
 }
 
 // Builds


### PR DESCRIPTION
found via go vet

```bash
$ go vet ./...
build.go:151: struct field tag `json:"runs` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
```