### PR TITLE
To stop a running build the request should be POST

### DIFF
--- a/build.go
+++ b/build.go
@@ -193,7 +193,7 @@ func (b *Build) GetCulprits() []culprit {
 
 func (b *Build) Stop() (bool, error) {
 	if b.IsRunning() {
-		_, err := b.Jenkins.Requester.GetJSON(b.Base+"/stop", nil, nil)
+		_, err := b.Jenkins.Requester.Post(b.Base+"/stop", nil, nil, nil)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Jenkins was complaining when trying to stop a running build by GET request: `POST is required for hudson.model.AbstractBuild.doStop`.

Thanks for open sourcing this repository :+1: 