### PR TITLE
Remove loop call to GetNode in GetAllNodes

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -292,13 +292,9 @@ func (j *Jenkins) GetAllNodes() ([]*Node, error) {
 
 	nodes := make([]*Node, len(computers.Computers))
 	for i, node := range computers.Computers {
-		name := node.DisplayName
-		// Special Case - Master Node
-		if name == "master" {
-			name = "(master)"
-		}
-		nodes[i], _ = j.GetNode(name)
+		nodes[i] = &Node{Jenkins: j, Raw: node, Base: "/computer/" + node.DisplayName}
 	}
+
 	return nodes, nil
 }
 

--- a/node.go
+++ b/node.go
@@ -19,10 +19,10 @@ import "errors"
 // Nodes
 
 type Computers struct {
-	BusyExecutors  int            `json:"busyExecutors"`
-	Computers      []nodeResponse `json:"computer"`
-	DisplayName    string         `json:"displayName"`
-	TotalExecutors int            `json:"totalExecutors"`
+	BusyExecutors  int             `json:"busyExecutors"`
+	Computers      []*nodeResponse `json:"computer"`
+	DisplayName    string          `json:"displayName"`
+	TotalExecutors int             `json:"totalExecutors"`
 }
 
 type Node struct {


### PR DESCRIPTION
Calling GetNode in GetAllNodes causes performance issues, as it's making
a redundant call for each node in the response for the exact same information
that GetAllNodes responds with. 

Fixes #27.