### PR TITLE
Export gojenkins.NodeResponse

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -156,7 +156,7 @@ func (j *Jenkins) CreateNode(name string, numExecutors int, description string, 
 		return nil, errors.New("launcher method not supported")
 	}
 
-	node = &Node{Jenkins: j, Raw: new(nodeResponse), Base: "/computer/" + name}
+	node = &Node{Jenkins: j, Raw: new(NodeResponse), Base: "/computer/" + name}
 	NODE_TYPE := "hudson.slaves.DumbSlave$DescriptorImpl"
 	MODE := "NORMAL"
 	qr := map[string]string{
@@ -247,7 +247,7 @@ func (j *Jenkins) BuildJob(name string, options ...interface{}) (bool, error) {
 }
 
 func (j *Jenkins) GetNode(name string) (*Node, error) {
-	node := Node{Jenkins: j, Raw: new(nodeResponse), Base: "/computer/" + name}
+	node := Node{Jenkins: j, Raw: new(NodeResponse), Base: "/computer/" + name}
 	status, err := node.Poll()
 	if err != nil {
 		return nil, err
@@ -285,6 +285,7 @@ func (j *Jenkins) GetJob(id string) (*Job, error) {
 
 func (j *Jenkins) GetAllNodes() ([]*Node, error) {
 	computers := new(Computers)
+
 	_, err := j.Requester.GetJSON("/computer", computers, nil)
 	if err != nil {
 		return nil, err

--- a/node.go
+++ b/node.go
@@ -20,18 +20,18 @@ import "errors"
 
 type Computers struct {
 	BusyExecutors  int             `json:"busyExecutors"`
-	Computers      []*nodeResponse `json:"computer"`
+	Computers      []*NodeResponse `json:"computer"`
 	DisplayName    string          `json:"displayName"`
 	TotalExecutors int             `json:"totalExecutors"`
 }
 
 type Node struct {
-	Raw     *nodeResponse
+	Raw     *NodeResponse
 	Jenkins *Jenkins
 	Base    string
 }
 
-type nodeResponse struct {
+type NodeResponse struct {
 	Actions             []interface{} `json:"actions"`
 	DisplayName         string        `json:"displayName"`
 	Executors           []struct{}    `json:"executors"`
@@ -60,7 +60,7 @@ type nodeResponse struct {
 	TemporarilyOffline bool          `json:"temporarilyOffline"`
 }
 
-func (n *Node) Info() (*nodeResponse, error) {
+func (n *Node) Info() (*NodeResponse, error) {
 	_, err := n.Poll()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fixes #29. Exports `NodeResponse` as a part of `gojenkins`.