### PR TITLE
Update NodeResponse by exporting and adding Executors

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -286,7 +286,11 @@ func (j *Jenkins) GetJob(id string) (*Job, error) {
 func (j *Jenkins) GetAllNodes() ([]*Node, error) {
 	computers := new(Computers)
 
-	_, err := j.Requester.GetJSON("/computer", computers, nil)
+	qr := map[string]string{
+		"depth": "1",
+	}
+
+	_, err := j.Requester.GetJSON("/computer", computers, qr)
 	if err != nil {
 		return nil, err
 	}

--- a/node.go
+++ b/node.go
@@ -32,16 +32,35 @@ type Node struct {
 }
 
 type NodeResponse struct {
-	Actions             []interface{} `json:"actions"`
-	DisplayName         string        `json:"displayName"`
-	Executors           []struct{}    `json:"executors"`
-	Icon                string        `json:"icon"`
-	IconClassName       string        `json:"iconClassName"`
-	Idle                bool          `json:"idle"`
-	JnlpAgent           bool          `json:"jnlpAgent"`
-	LaunchSupported     bool          `json:"launchSupported"`
-	LoadStatistics      struct{}      `json:"loadStatistics"`
-	ManualLaunchAllowed bool          `json:"manualLaunchAllowed"`
+	Actions     []interface{} `json:"actions"`
+	DisplayName string        `json:"displayName"`
+	Executors   []struct {
+		CurrentExecutable struct {
+			Number    int    `json:"number"`
+			URL       string `json:"url"`
+			SubBuilds []struct {
+				Abort             bool        `json:"abort"`
+				Build             interface{} `json:"build"`
+				BuildNumber       int         `json:"buildNumber"`
+				Duration          string      `json:"duration"`
+				Icon              string      `json:"icon"`
+				JobName           string      `json:"jobName"`
+				ParentBuildNumber int         `json:"parentBuildNumber"`
+				ParentJobName     string      `json:"parentJobName"`
+				PhaseName         string      `json:"phaseName"`
+				Result            string      `json:"result"`
+				Retry             bool        `json:"retry"`
+				URL               string      `json:"url"`
+			} `json:"subBuilds"`
+		} `json:"currentExecutable"`
+	} `json:"executors"`
+	Icon                string   `json:"icon"`
+	IconClassName       string   `json:"iconClassName"`
+	Idle                bool     `json:"idle"`
+	JnlpAgent           bool     `json:"jnlpAgent"`
+	LaunchSupported     bool     `json:"launchSupported"`
+	LoadStatistics      struct{} `json:"loadStatistics"`
+	ManualLaunchAllowed bool     `json:"manualLaunchAllowed"`
 	MonitorData         struct {
 		Hudson_NodeMonitors_ArchitectureMonitor interface{} `json:"hudson.node_monitors.ArchitectureMonitor"`
 		Hudson_NodeMonitors_ClockMonitor        interface{} `json:"hudson.node_monitors.ClockMonitor"`


### PR DESCRIPTION
Add executors definition within NodeResponse, add NodeResponse as an export.