### PR TITLE
Requester thread-safety problems

### DIFF
--- a/artifact.go
+++ b/artifact.go
@@ -35,13 +35,13 @@ type Artifact struct {
 // Get raw byte data of Artifact
 func (a Artifact) GetData() ([]byte, error) {
 	var data string
-	_, err := a.Jenkins.Requester.Get(a.Path, &data, nil)
+	response, err := a.Jenkins.Requester.Get(a.Path, &data, nil)
 
 	if err != nil {
 		return nil, err
 	}
 
-	code := a.Jenkins.Requester.LastResponse.StatusCode
+	code := response.StatusCode
 	if code != 200 {
 		Error.Printf("Jenkins responded with StatusCode: %d", code)
 		return nil, errors.New("Could not get File Contents")

--- a/build.go
+++ b/build.go
@@ -193,11 +193,11 @@ func (b *Build) GetCulprits() []culprit {
 
 func (b *Build) Stop() (bool, error) {
 	if b.IsRunning() {
-		_, err := b.Jenkins.Requester.Post(b.Base+"/stop", nil, nil, nil)
+		response, err := b.Jenkins.Requester.Post(b.Base+"/stop", nil, nil, nil)
 		if err != nil {
 			return false, err
 		}
-		return b.Jenkins.Requester.LastResponse.StatusCode == 200, nil
+		return response.StatusCode == 200, nil
 	}
 	return true, nil
 }
@@ -444,9 +444,9 @@ func (b *Build) Poll(options ...interface{}) (int, error) {
 	qr := map[string]string{
 		"depth": depth,
 	}
-	_, err := b.Jenkins.Requester.GetJSON(b.Base, b.Raw, qr)
+	response, err := b.Jenkins.Requester.GetJSON(b.Base, b.Raw, qr)
 	if err != nil {
 		return 0, err
 	}
-	return b.Jenkins.Requester.LastResponse.StatusCode, nil
+	return response.StatusCode, nil
 }

--- a/fingerprint.go
+++ b/fingerprint.go
@@ -87,9 +87,9 @@ func (f Fingerprint) GetInfo() (*fingerPrintResponse, error) {
 }
 
 func (f Fingerprint) Poll() (int, error) {
-	_, err := f.Jenkins.Requester.GetJSON(f.Base+f.Id, f.Raw, nil)
+	response, err := f.Jenkins.Requester.GetJSON(f.Base+f.Id, f.Raw, nil)
 	if err != nil {
 		return 0, err
 	}
-	return f.Jenkins.Requester.LastResponse.StatusCode, nil
+	return response.StatusCode, nil
 }

--- a/jenkins.go
+++ b/jenkins.go
@@ -107,7 +107,7 @@ func (j *Jenkins) initLoggers() {
 
 // Get Basic Information About Jenkins
 func (j *Jenkins) Info() (*executorResponse, error) {
-	_, err := j.Requester.Do("GET", "/", nil, j.Raw, nil)
+	_, err := j.Requester.Get("/", j.Raw, nil)
 
 	if err != nil {
 		return nil, err
@@ -476,11 +476,11 @@ func (j *Jenkins) CreateView(name string, viewType string) (*View, error) {
 }
 
 func (j *Jenkins) Poll() (int, error) {
-	_, err := j.Requester.GetJSON("/", j.Raw, nil)
+	resp, err := j.Requester.GetJSON("/", j.Raw, nil)
 	if err != nil {
 		return 0, err
 	}
-	return j.Requester.LastResponse.StatusCode, nil
+	return resp.StatusCode, nil
 }
 
 // Creates a new Jenkins Instance
@@ -492,7 +492,7 @@ func CreateJenkins(base string, auth ...interface{}) *Jenkins {
 		base = base[:len(base)-1]
 	}
 	j.Server = base
-	j.Requester = &Requester{Base: base, SslVerify: false, Headers: http.Header{}}
+	j.Requester = &Requester{Base: base, SslVerify: false}
 	if len(auth) == 2 {
 		j.Requester.BasicAuth = &BasicAuth{Username: auth[0].(string), Password: auth[1].(string)}
 	}

--- a/job.go
+++ b/job.go
@@ -435,9 +435,9 @@ func (j *Job) Invoke(files []string, skipIfRunning bool, params map[string]strin
 }
 
 func (j *Job) Poll() (int, error) {
-	_, err := j.Jenkins.Requester.GetJSON(j.Base, j.Raw, nil)
+	response, err := j.Jenkins.Requester.GetJSON(j.Base, j.Raw, nil)
 	if err != nil {
 		return 0, err
 	}
-	return j.Jenkins.Requester.LastResponse.StatusCode, nil
+	return response.StatusCode, nil
 }

--- a/node.go
+++ b/node.go
@@ -180,11 +180,11 @@ func (n *Node) ToggleTemporarilyOffline(options ...interface{}) (bool, error) {
 }
 
 func (n *Node) Poll() (int, error) {
-	_, err := n.Jenkins.Requester.GetJSON(n.Base, n.Raw, nil)
+	response, err := n.Jenkins.Requester.GetJSON(n.Base, n.Raw, nil)
 	if err != nil {
 		return 0, err
 	}
-	return n.Jenkins.Requester.LastResponse.StatusCode, nil
+	return response.StatusCode, nil
 }
 
 func (n *Node) LaunchNodeBySSH() (int, error) {
@@ -192,11 +192,11 @@ func (n *Node) LaunchNodeBySSH() (int, error) {
 		"json":   "",
 		"Submit": "Launch slave agent",
 	}
-	_, err := n.Jenkins.Requester.Post(n.Base+"/launchSlaveAgent", nil, nil, qr)
+	response, err := n.Jenkins.Requester.Post(n.Base+"/launchSlaveAgent", nil, nil, qr)
 	if err != nil {
 		return 0, err
 	}
-	return n.Jenkins.Requester.LastResponse.StatusCode, nil
+	return response.StatusCode, nil
 }
 
 func (n *Node) Disconnect() (int, error) {
@@ -205,11 +205,11 @@ func (n *Node) Disconnect() (int, error) {
 		"json":           makeJson(map[string]string{"offlineMessage": ""}),
 		"Submit":         "Yes",
 	}
-	_, err := n.Jenkins.Requester.Post(n.Base+"/doDisconnect", nil, nil, qr)
+	response, err := n.Jenkins.Requester.Post(n.Base+"/doDisconnect", nil, nil, qr)
 	if err != nil {
 		return 0, err
 	}
-	return n.Jenkins.Requester.LastResponse.StatusCode, nil
+	return response.StatusCode, nil
 }
 
 func (n *Node) GetLogText() (string, error) {

--- a/plugin.go
+++ b/plugin.go
@@ -67,9 +67,9 @@ func (p *Plugins) Poll() (int, error) {
 	qr := map[string]string{
 		"depth": strconv.Itoa(p.Depth),
 	}
-	_, err := p.Jenkins.Requester.GetJSON(p.Base, p.Raw, qr)
+	response, err := p.Jenkins.Requester.GetJSON(p.Base, p.Raw, qr)
 	if err != nil {
 		return 0, err
 	}
-	return p.Jenkins.Requester.LastResponse.StatusCode, nil
+	return response.StatusCode, nil
 }

--- a/queue.go
+++ b/queue.go
@@ -94,11 +94,11 @@ func (t *Task) Cancel() (bool, error) {
 	qr := map[string]string{
 		"id": strconv.FormatInt(t.Raw.ID, 10),
 	}
-	_, err := t.Jenkins.Requester.Post(t.Jenkins.GetQueueUrl()+"/cancelItem", nil, t.Raw, qr)
+	response, err := t.Jenkins.Requester.Post(t.Jenkins.GetQueueUrl()+"/cancelItem", nil, t.Raw, qr)
 	if err != nil {
 		return false, err
 	}
-	return t.Jenkins.Requester.LastResponse.StatusCode == 200, nil
+	return response.StatusCode == 200, nil
 }
 
 func (t *Task) GetJob() (*Job, error) {
@@ -128,9 +128,9 @@ func (t *Task) GetCauses() []map[string]interface{} {
 }
 
 func (q *Queue) Poll() (int, error) {
-	_, err := q.Jenkins.Requester.GetJSON(q.Base, q.Raw, nil)
+	response, err := q.Jenkins.Requester.GetJSON(q.Base, q.Raw, nil)
 	if err != nil {
 		return 0, err
 	}
-	return q.Jenkins.Requester.LastResponse.StatusCode, nil
+	return response.StatusCode, nil
 }

--- a/views.go
+++ b/views.go
@@ -86,9 +86,9 @@ func (v *View) GetUrl() string {
 }
 
 func (v *View) Poll() (int, error) {
-	_, err := v.Jenkins.Requester.GetJSON(v.Base, v.Raw, nil)
+	response, err := v.Jenkins.Requester.GetJSON(v.Base, v.Raw, nil)
 	if err != nil {
 		return 0, err
 	}
-	return v.Jenkins.Requester.LastResponse.StatusCode, nil
+	return response.StatusCode, nil
 }


### PR DESCRIPTION
Please consider this PR aiming to fix #35. Mutable state is moved from ````Requester```` to new struct ```APIRequest``` which will be instantiated on the stack of the calling goroutine. That should make ````Requester```` safe for concurrent use (I have add some trivial tests that perform conccurrent calls of the ```Requester```).

```Requester``` interface was not changed with the exception of ```Do``` method (I hope that this change will not affect users, because I would suggest clients not to use this method directly).
How it looked before:
`func (r *Requester) Do(method string, endpoint string, payload io.Reader, responseStruct interface{}, options ...interface{}) (*http.Response, error)`
How it looks now:
`func (r *Requester) Do(ar *APIRequest, responseStruct interface{}, options ...interface{}) (*http.Response, error)`

Probably there are still similar problems with other parts of this library. I'm going to do some investigation while writing clientside code, but I hope that at least ```Requester```  is thread-safe now.