### PR TITLE
Don't println CreateView error 

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -461,7 +461,6 @@ func (j *Jenkins) CreateView(name string, viewType string) (*View, error) {
 		return nil, err
 	}
 	if exists.Raw.Name != "" {
-		Error.Println("View Already exists.")
 		return exists, errors.New("View already exists")
 	}
 	view := &View{Jenkins: j, Raw: new(ViewResponse), Base: "/view/" + name}


### PR DESCRIPTION
my use case is that I'm creating a view, however it's fine if it already exists, I just handle that condition and move on. however the lib prints out an error which could confuse a user into thinking there's a problem when there isn't. this just removes the println.