### PR TITLE
Create GetJobXML function

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -334,6 +334,18 @@ func (j *Jenkins) GetJob(id string, parentIDs ...string) (*Job, error) {
 	return nil, errors.New(strconv.Itoa(status))
 }
 
+func (j *Jenkins) GetJobXML(id string, parentIDs ...string) (string, error) {
+	var job string
+	response, err := j.Requester.GetXML("/job/"+strings.Join(append(parentIDs, id), "/")+"/config.xml", &job, nil)
+	if err != nil {
+		return "", fmt.Errorf("error getting job XML: %v", err)
+	}
+	if response.StatusCode == http.StatusOK {
+		return job, nil
+	}
+	return "", errors.New(strconv.Itoa(response.StatusCode))
+}
+
 func (j *Jenkins) GetSubJob(parentId string, childId string) (*Job, error) {
 	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + parentId + "/job/" + childId}
 	status, err := job.Poll()

--- a/jenkins.go
+++ b/jenkins.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/cookiejar"
@@ -343,7 +344,9 @@ func (j *Jenkins) GetJobXML(id string, parentIDs ...string) (string, error) {
 	if response.StatusCode == http.StatusOK {
 		return job, nil
 	}
-	return "", errors.New(strconv.Itoa(response.StatusCode))
+
+	body, _ := ioutil.ReadAll(response.Body)
+	return "", fmt.Errorf("status code: %d, body: %s", response.StatusCode, string(body))
 }
 
 func (j *Jenkins) GetSubJob(parentId string, childId string) (*Job, error) {

--- a/jenkins.go
+++ b/jenkins.go
@@ -346,7 +346,7 @@ func (j *Jenkins) GetJobXML(id string, parentIDs ...string) (string, error) {
 	}
 
 	body, _ := ioutil.ReadAll(response.Body)
-	return "", fmt.Errorf("status code: %d, body: %s", response.StatusCode, string(body))
+	return "", fmt.Errorf("status code: %d, body: %s, headers: %#v", response.StatusCode, string(body), response.Header)
 }
 
 func (j *Jenkins) GetSubJob(parentId string, childId string) (*Job, error) {

--- a/jenkins.go
+++ b/jenkins.go
@@ -269,8 +269,8 @@ func (j *Jenkins) CopyJob(copyFrom string, newName string) (*Job, error) {
 }
 
 // Delete a job.
-func (j *Jenkins) DeleteJob(name string) (bool, error) {
-	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + name}
+func (j *Jenkins) DeleteJob(name string, parentIDs ...string) (bool, error) {
+	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + strings.Join(append(parentIDs, name), "/")}
 	return job.Delete()
 }
 

--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -222,6 +222,20 @@ func TestGetFolder(t *testing.T) {
 	assert.Equal(t, folder2ID, folder2.GetName())
 }
 
+func TestGetJobXML(t *testing.T) {
+	job1ID := "Job1_xml_test"
+	job_data := getFileAsString("job.xml")
+	job1, err := jenkins.CreateJob(job_data, job1ID)
+	assert.Nil(t, err)
+	assert.NotNil(t, job1)
+	assert.Equal(t, "Some Job Description", job1.GetDescription())
+	assert.Equal(t, job1ID, job1.GetName())
+
+	xml, err := jenkins.GetJobXML(job1ID)
+	assert.Nil(t, err)
+	assert.Contains(t, xml, `<description>Some Job Description</description>`)
+}
+
 func TestConcurrentRequests(t *testing.T) {
 	for i := 0; i <= 16; i++ {
 		go func() {

--- a/job.go
+++ b/job.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"path"
 	"strconv"
@@ -69,18 +70,18 @@ type JobResponse struct {
 		IconUrl       string `json:"iconUrl"`
 		Score         int64  `json:"score"`
 	} `json:"healthReport"`
-	InQueue               bool     `json:"inQueue"`
-	KeepDependencies      bool     `json:"keepDependencies"`
-	LastBuild             JobBuild `json:"lastBuild"`
-	LastCompletedBuild    JobBuild `json:"lastCompletedBuild"`
-	LastFailedBuild       JobBuild `json:"lastFailedBuild"`
-	LastStableBuild       JobBuild `json:"lastStableBuild"`
-	LastSuccessfulBuild   JobBuild `json:"lastSuccessfulBuild"`
-	LastUnstableBuild     JobBuild `json:"lastUnstableBuild"`
-	LastUnsuccessfulBuild JobBuild `json:"lastUnsuccessfulBuild"`
-	Name                  string   `json:"name"`
-	SubJobs               []InnerJob    `json:"jobs"`
-	NextBuildNumber       int64    `json:"nextBuildNumber"`
+	InQueue               bool       `json:"inQueue"`
+	KeepDependencies      bool       `json:"keepDependencies"`
+	LastBuild             JobBuild   `json:"lastBuild"`
+	LastCompletedBuild    JobBuild   `json:"lastCompletedBuild"`
+	LastFailedBuild       JobBuild   `json:"lastFailedBuild"`
+	LastStableBuild       JobBuild   `json:"lastStableBuild"`
+	LastSuccessfulBuild   JobBuild   `json:"lastSuccessfulBuild"`
+	LastUnstableBuild     JobBuild   `json:"lastUnstableBuild"`
+	LastUnsuccessfulBuild JobBuild   `json:"lastUnsuccessfulBuild"`
+	Name                  string     `json:"name"`
+	SubJobs               []InnerJob `json:"jobs"`
+	NextBuildNumber       int64      `json:"nextBuildNumber"`
 	Property              []struct {
 		ParameterDefinitions []ParameterDefinition `json:"parameterDefinitions"`
 	} `json:"property"`
@@ -298,7 +299,8 @@ func (j *Job) Delete() (bool, error) {
 		return false, err
 	}
 	if resp.StatusCode != 200 {
-		return false, errors.New(strconv.Itoa(resp.StatusCode))
+		body, _ := ioutil.ReadAll(resp.Body)
+		return false, fmt.Errorf("status code: %d, body: %s", resp.StatusCode, string(body))
 	}
 	return true, nil
 }
@@ -326,7 +328,9 @@ func (j *Job) Create(config string, qr ...interface{}) (*Job, error) {
 		j.Poll()
 		return j, nil
 	}
-	return nil, errors.New(strconv.Itoa(resp.StatusCode))
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	return nil, fmt.Errorf("status code: %d, body: %s", resp.StatusCode, string(body))
 }
 
 func (j *Job) Copy(destinationName string) (*Job, error) {

--- a/job.go
+++ b/job.go
@@ -300,7 +300,7 @@ func (j *Job) Delete() (bool, error) {
 	}
 	if resp.StatusCode != 200 {
 		body, _ := ioutil.ReadAll(resp.Body)
-		return false, fmt.Errorf("status code: %d, body: %s", resp.StatusCode, string(body))
+		return false, fmt.Errorf("status code: %d, body: %s, headers: %#v", resp.StatusCode, string(body), resp.Header)
 	}
 	return true, nil
 }
@@ -330,7 +330,7 @@ func (j *Job) Create(config string, qr ...interface{}) (*Job, error) {
 	}
 
 	body, _ := ioutil.ReadAll(resp.Body)
-	return nil, fmt.Errorf("status code: %d, body: %s", resp.StatusCode, string(body))
+	return nil, fmt.Errorf("status code: %d, body: %s, headers: %#v", resp.StatusCode, string(body), resp.Header)
 }
 
 func (j *Job) Copy(destinationName string) (*Job, error) {


### PR DESCRIPTION
This function allows us to fetch the raw XML for a job. The Jenkins
JSON API only returns a subset of the information that's included in a
job's configuration, so the XML endpoint is the only way to pull down
a job's entire configuration.