### PR TITLE
Add ability to pass offline reason in SetOffline

### DIFF
--- a/node.go
+++ b/node.go
@@ -149,9 +149,9 @@ func (n *Node) SetOnline() (bool, error) {
 	return true, nil
 }
 
-func (n *Node) SetOffline() (bool, error) {
+func (n *Node) SetOffline(options ...interface{}) (bool, error) {
 	if !n.Raw.Offline {
-		return n.ToggleTemporarilyOffline()
+		return n.ToggleTemporarilyOffline(options...)
 	}
 	return false, errors.New("Node already Offline")
 }


### PR DESCRIPTION
The `SetOffline` method currently does not allow you to pass in an offline reason to the underlying `ToggleTemporarilyOffline` which allows it. Adding a variadic argument here to `SetOffline` so that the offline reason string can be passed down `ToggleTemporarilyOffline`.