### PR TITLE
fixing linting errors for gosimple, comments and errcheck. 

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -14,14 +14,19 @@
 
 package gojenkins
 
+// Executor represents an executor
 type Executor struct {
 	Raw     *ExecutorResponse
 	Jenkins *Jenkins
 }
+
+// ViewData represents ViewData
 type ViewData struct {
 	Name string `json:"name"`
 	URL  string `json:"url"`
 }
+
+// ExecutorResponse represents an executor response
 type ExecutorResponse struct {
 	AssignedLabels  []struct{}  `json:"assignedLabels"`
 	Description     interface{} `json:"description"`

--- a/fingerprint.go
+++ b/fingerprint.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 )
 
+// Fingerprint represents a Fingerprint
 type Fingerprint struct {
 	Jenkins *Jenkins
 	Base    string
@@ -45,6 +46,7 @@ type fingerPrintResponse struct {
 	} `json:"usage"`
 }
 
+// Valid returns if a fingerprint is valid
 func (f Fingerprint) Valid() (bool, error) {
 	status, err := f.Poll()
 
@@ -53,11 +55,12 @@ func (f Fingerprint) Valid() (bool, error) {
 	}
 
 	if status != 200 || f.Raw.Hash != f.Id {
-		return false, errors.New(fmt.Sprintf("Jenkins says %s is Invalid or the Status is unknown", f.Id))
+		return false, fmt.Errorf("Jenkins says %s is Invalid or the Status is unknown", f.Id)
 	}
 	return true, nil
 }
 
+// ValidateForBuild validates the fingerprint for a build
 func (f Fingerprint) ValidateForBuild(filename string, build *Build) (bool, error) {
 	valid, err := f.Valid()
 	if err != nil {
@@ -78,6 +81,7 @@ func (f Fingerprint) ValidateForBuild(filename string, build *Build) (bool, erro
 	return false, nil
 }
 
+// GetInfo gets a fingerprint's info
 func (f Fingerprint) GetInfo() (*fingerPrintResponse, error) {
 	_, err := f.Poll()
 	if err != nil {
@@ -86,6 +90,7 @@ func (f Fingerprint) GetInfo() (*fingerPrintResponse, error) {
 	return f.Raw, nil
 }
 
+// Poll polls a fingerprint
 func (f Fingerprint) Poll() (int, error) {
 	response, err := f.Jenkins.Requester.GetJSON(f.Base+f.Id, f.Raw, nil)
 	if err != nil {

--- a/folder.go
+++ b/folder.go
@@ -20,12 +20,14 @@ import (
 	"strings"
 )
 
+// Folder represents a folder
 type Folder struct {
 	Raw     *FolderResponse
 	Jenkins *Jenkins
 	Base    string
 }
 
+// FolderResponse represents a folder response
 type FolderResponse struct {
 	Actions     []generalObj
 	Description string     `json:"description"`
@@ -41,10 +43,12 @@ func (f *Folder) parentBase() string {
 	return f.Base[:strings.LastIndex(f.Base, "/job")]
 }
 
+// GetName returns a folder name
 func (f *Folder) GetName() string {
 	return f.Raw.Name
 }
 
+// Create creates a folder
 func (f *Folder) Create(name string) (*Folder, error) {
 	mode := "com.cloudbees.hudson.plugins.folder.Folder"
 	data := map[string]string{
@@ -61,12 +65,13 @@ func (f *Folder) Create(name string) (*Folder, error) {
 		return nil, err
 	}
 	if r.StatusCode == 200 {
-		f.Poll()
+		_, _ = f.Poll()
 		return f, nil
 	}
 	return nil, errors.New(strconv.Itoa(r.StatusCode))
 }
 
+// Poll polls a folder
 func (f *Folder) Poll() (int, error) {
 	response, err := f.Jenkins.Requester.GetJSON(f.Base, f.Raw, nil)
 	if err != nil {

--- a/job.go
+++ b/job.go
@@ -25,23 +25,27 @@ import (
 	"strings"
 )
 
+// Job represents a jenkins job
 type Job struct {
 	Raw     *JobResponse
 	Jenkins *Jenkins
 	Base    string
 }
 
+// JobBuild represents a jenkins job build
 type JobBuild struct {
 	Number int64
 	URL    string
 }
 
+// InnerJob represents an inner job
 type InnerJob struct {
 	Name  string `json:"name"`
 	Url   string `json:"url"`
 	Color string `json:"color"`
 }
 
+// ParameterDefinition represents a parameter definition
 type ParameterDefinition struct {
 	DefaultParameterValue struct {
 		Name  string      `json:"name"`
@@ -52,6 +56,7 @@ type ParameterDefinition struct {
 	Type        string `json:"type"`
 }
 
+// JobResponse represents a job response
 type JobResponse struct {
 	Actions            []generalObj
 	Buildable          bool `json:"buildable"`
@@ -79,7 +84,6 @@ type JobResponse struct {
 	LastUnstableBuild     JobBuild `json:"lastUnstableBuild"`
 	LastUnsuccessfulBuild JobBuild `json:"lastUnsuccessfulBuild"`
 	Name                  string   `json:"name"`
-	SubJobs               []InnerJob    `json:"jobs"`
 	NextBuildNumber       int64    `json:"nextBuildNumber"`
 	Property              []struct {
 		ParameterDefinitions []ParameterDefinition `json:"parameterDefinitions"`
@@ -93,28 +97,37 @@ type JobResponse struct {
 	Views            []ViewData  `json:"views"`
 }
 
+// SubJobs gets subjobs
+func (j *Job) SubJobs() []InnerJob {
+	return j.Raw.Jobs
+}
 func (j *Job) parentBase() string {
 	return j.Base[:strings.LastIndex(j.Base, "/job/")]
 }
 
+// History represents a build history
 type History struct {
 	BuildNumber    int
 	BuildStatus    string
 	BuildTimestamp int64
 }
 
+// GetName gets the name for a job
 func (j *Job) GetName() string {
 	return j.Raw.Name
 }
 
+// GetDescription gets the description for a job
 func (j *Job) GetDescription() string {
 	return j.Raw.Description
 }
 
+// GetDetails gets the details for a job
 func (j *Job) GetDetails() *JobResponse {
 	return j.Raw
 }
 
+// GetBuild gets a job build by id
 func (j *Job) GetBuild(id int64) (*Build, error) {
 	build := Build{Jenkins: j.Jenkins, Job: j, Raw: new(BuildResponse), Depth: 1, Base: "/job/" + j.GetName() + "/" + strconv.FormatInt(id, 10)}
 	status, err := build.Poll()
@@ -158,31 +171,37 @@ func (j *Job) getBuildByType(buildType string) (*Build, error) {
 	return nil, errors.New(strconv.Itoa(status))
 }
 
+// GetLastSuccessfulBuild gets the last successful build for a job
 func (j *Job) GetLastSuccessfulBuild() (*Build, error) {
 	return j.getBuildByType("lastSuccessfulBuild")
 }
 
+// GetFirstBuild gets the first build for a job
 func (j *Job) GetFirstBuild() (*Build, error) {
 	return j.getBuildByType("firstBuild")
 }
 
+// GetLastBuild gets the last build for a job
 func (j *Job) GetLastBuild() (*Build, error) {
 	return j.getBuildByType("lastBuild")
 }
 
+// GetLastStableBuild gets the last stable build for a job
 func (j *Job) GetLastStableBuild() (*Build, error) {
 	return j.getBuildByType("lastStableBuild")
 }
 
+// GetLastFailedBuild gets the last failed build for a job
 func (j *Job) GetLastFailedBuild() (*Build, error) {
 	return j.getBuildByType("lastFailedBuild")
 }
 
+// GetLastCompletedBuild gets the last completed build for a job
 func (j *Job) GetLastCompletedBuild() (*Build, error) {
 	return j.getBuildByType("lastCompletedBuild")
 }
 
-// Returns All Builds with Number and URL
+// GetAllBuildIds Returns All Builds with Number and URL
 func (j *Job) GetAllBuildIds() ([]JobBuild, error) {
 	var buildsResp struct {
 		Builds []JobBuild `json:"allBuilds"`
@@ -194,21 +213,25 @@ func (j *Job) GetAllBuildIds() ([]JobBuild, error) {
 	return buildsResp.Builds, nil
 }
 
+// GetSubJobsMetadata gets the metadata for subjobs
 func (j *Job) GetSubJobsMetadata() []InnerJob {
-	return j.Raw.SubJobs
+	return j.SubJobs()
 }
 
+// GetUpstreamJobsMetadata gets the metadata for upstream jobs
 func (j *Job) GetUpstreamJobsMetadata() []InnerJob {
 	return j.Raw.UpstreamProjects
 }
 
+// GetDownstreamJobsMetadata gets the metadata for downstream jobs
 func (j *Job) GetDownstreamJobsMetadata() []InnerJob {
 	return j.Raw.DownstreamProjects
 }
 
+// GetSubJobs gets the subjobs for a job
 func (j *Job) GetSubJobs() ([]*Job, error) {
-	jobs := make([]*Job, len(j.Raw.SubJobs))
-	for i, job := range j.Raw.SubJobs {
+	jobs := make([]*Job, len(j.SubJobs()))
+	for i, job := range j.SubJobs() {
 		ji, err := j.Jenkins.GetSubJob(j.GetName(), job.Name)
 		if err != nil {
 			return nil, err
@@ -218,10 +241,12 @@ func (j *Job) GetSubJobs() ([]*Job, error) {
 	return jobs, nil
 }
 
+// GetInnerJobsMetadata gets the metadata for a job's inner jobs
 func (j *Job) GetInnerJobsMetadata() []InnerJob {
 	return j.Raw.Jobs
 }
 
+// GetUpstreamJobs gets the jobs that are upstream of the current job
 func (j *Job) GetUpstreamJobs() ([]*Job, error) {
 	jobs := make([]*Job, len(j.Raw.UpstreamProjects))
 	for i, job := range j.Raw.UpstreamProjects {
@@ -234,6 +259,7 @@ func (j *Job) GetUpstreamJobs() ([]*Job, error) {
 	return jobs, nil
 }
 
+// GetDownstreamJobs gets the jobs that are downstream of the current job
 func (j *Job) GetDownstreamJobs() ([]*Job, error) {
 	jobs := make([]*Job, len(j.Raw.DownstreamProjects))
 	for i, job := range j.Raw.DownstreamProjects {
@@ -246,6 +272,7 @@ func (j *Job) GetDownstreamJobs() ([]*Job, error) {
 	return jobs, nil
 }
 
+// GetInnerJob gets an inner job for a job by id
 func (j *Job) GetInnerJob(id string) (*Job, error) {
 	job := Job{Jenkins: j.Jenkins, Raw: new(JobResponse), Base: j.Base + "/job/" + id}
 	status, err := job.Poll()
@@ -258,6 +285,7 @@ func (j *Job) GetInnerJob(id string) (*Job, error) {
 	return nil, errors.New(strconv.Itoa(status))
 }
 
+// GetInnerJobs gets all the inner jobs for the current job
 func (j *Job) GetInnerJobs() ([]*Job, error) {
 	jobs := make([]*Job, len(j.Raw.Jobs))
 	for i, job := range j.Raw.Jobs {
@@ -270,6 +298,7 @@ func (j *Job) GetInnerJobs() ([]*Job, error) {
 	return jobs, nil
 }
 
+// Enable enables the current job
 func (j *Job) Enable() (bool, error) {
 	resp, err := j.Jenkins.Requester.Post(j.Base+"/enable", nil, nil, nil)
 	if err != nil {
@@ -281,6 +310,7 @@ func (j *Job) Enable() (bool, error) {
 	return true, nil
 }
 
+// Disable disables the current job
 func (j *Job) Disable() (bool, error) {
 	resp, err := j.Jenkins.Requester.Post(j.Base+"/disable", nil, nil, nil)
 	if err != nil {
@@ -292,6 +322,7 @@ func (j *Job) Disable() (bool, error) {
 	return true, nil
 }
 
+// Delete deletes the current job
 func (j *Job) Delete() (bool, error) {
 	resp, err := j.Jenkins.Requester.Post(j.Base+"/doDelete", nil, nil, nil)
 	if err != nil {
@@ -303,6 +334,7 @@ func (j *Job) Delete() (bool, error) {
 	return true, nil
 }
 
+// Rename renames the current job
 func (j *Job) Rename(name string) (bool, error) {
 	data := url.Values{}
 	data.Set("newName", name)
@@ -313,6 +345,7 @@ func (j *Job) Rename(name string) (bool, error) {
 	return true, nil
 }
 
+// Create creates the current job
 func (j *Job) Create(config string, qr ...interface{}) (*Job, error) {
 	var querystring map[string]string
 	if len(qr) > 0 {
@@ -329,6 +362,7 @@ func (j *Job) Create(config string, qr ...interface{}) (*Job, error) {
 	return nil, errors.New(strconv.Itoa(resp.StatusCode))
 }
 
+// Copy copies the current job to the destination name
 func (j *Job) Copy(destinationName string) (*Job, error) {
 	qr := map[string]string{"name": destinationName, "from": j.GetName(), "mode": "copy"}
 	resp, err := j.Jenkins.Requester.Post(j.parentBase()+"/createItem", nil, nil, qr)
@@ -346,6 +380,7 @@ func (j *Job) Copy(destinationName string) (*Job, error) {
 	return nil, errors.New(strconv.Itoa(resp.StatusCode))
 }
 
+// UpdateConfig updates the current job with the specified config
 func (j *Job) UpdateConfig(config string) error {
 
 	var querystring map[string]string
@@ -362,6 +397,7 @@ func (j *Job) UpdateConfig(config string) error {
 
 }
 
+// GetConfig gets the config for the current job
 func (j *Job) GetConfig() (string, error) {
 	var data string
 	_, err := j.Jenkins.Requester.GetXML(j.Base+"/config.xml", &data, nil)
@@ -371,6 +407,7 @@ func (j *Job) GetConfig() (string, error) {
 	return data, nil
 }
 
+// GetParameters gets the parameters for the current job
 func (j *Job) GetParameters() ([]ParameterDefinition, error) {
 	_, err := j.Poll()
 	if err != nil {
@@ -378,13 +415,12 @@ func (j *Job) GetParameters() ([]ParameterDefinition, error) {
 	}
 	var parameters []ParameterDefinition
 	for _, property := range j.Raw.Property {
-		for _, param := range property.ParameterDefinitions {
-			parameters = append(parameters, param)
-		}
+		parameters = append(parameters, property.ParameterDefinitions...)
 	}
 	return parameters, nil
 }
 
+// IsQueued returns the queued state of the current job
 func (j *Job) IsQueued() (bool, error) {
 	if _, err := j.Poll(); err != nil {
 		return false, err
@@ -392,6 +428,7 @@ func (j *Job) IsQueued() (bool, error) {
 	return j.Raw.InQueue, nil
 }
 
+// IsRunning returns if the current job is running
 func (j *Job) IsRunning() (bool, error) {
 	if _, err := j.Poll(); err != nil {
 		return false, err
@@ -403,6 +440,7 @@ func (j *Job) IsRunning() (bool, error) {
 	return lastBuild.IsRunning(), nil
 }
 
+// IsEnabled returns if the current job is enabled
 func (j *Job) IsEnabled() (bool, error) {
 	if _, err := j.Poll(); err != nil {
 		return false, err
@@ -410,10 +448,12 @@ func (j *Job) IsEnabled() (bool, error) {
 	return j.Raw.Color != "disabled", nil
 }
 
+// HasQueuedBuild returns if the current job has queued builds
 func (j *Job) HasQueuedBuild() {
 	panic("Not Implemented yet")
 }
 
+// InvokeSimple is a simple invocation method for the current job
 func (j *Job) InvokeSimple(params map[string]string) (int64, error) {
 	isQueued, err := j.IsQueued()
 	if err != nil {
@@ -463,6 +503,7 @@ func (j *Job) InvokeSimple(params map[string]string) (int64, error) {
 	return number, nil
 }
 
+// Invoke is a complex invocation method for the current job
 func (j *Job) Invoke(files []string, skipIfRunning bool, params map[string]string, cause string, securityToken string) (bool, error) {
 	isQueued, err := j.IsQueued()
 	if err != nil {
@@ -511,6 +552,7 @@ func (j *Job) Invoke(files []string, skipIfRunning bool, params map[string]strin
 	return false, errors.New(strconv.Itoa(resp.StatusCode))
 }
 
+// Poll polls the current job
 func (j *Job) Poll() (int, error) {
 	response, err := j.Jenkins.Requester.GetJSON(j.Base, j.Raw, nil)
 	if err != nil {
@@ -519,6 +561,7 @@ func (j *Job) Poll() (int, error) {
 	return response.StatusCode, nil
 }
 
+// History returns the history for the current job
 func (j *Job) History() ([]*History, error) {
 	resp, err := j.Jenkins.Requester.Get(j.Base+"/buildHistory/ajax", nil, nil)
 	if err != nil {

--- a/label.go
+++ b/label.go
@@ -14,19 +14,24 @@
 
 package gojenkins
 
+// Label represents a Label
 type Label struct {
 	Raw     *LabelResponse
 	Jenkins *Jenkins
 	Base    string
 }
 
+// MODE represents a node mode
 type MODE string
 
 const (
-	NORMAL    MODE = "NORMAL"
-	EXCLUSIVE      = "EXCLUSIVE"
+	// NORMAL is a constant for normal nodes
+	NORMAL MODE = "NORMAL"
+	// EXCLUSIVE is a constant for exclusive nodes
+	EXCLUSIVE = "EXCLUSIVE"
 )
 
+// LabelNode represents a labled node
 type LabelNode struct {
 	NodeName        string `json:"nodeName"`
 	NodeDescription string `json:"nodeDescription"`
@@ -35,6 +40,7 @@ type LabelNode struct {
 	Class           string `json:"_class"`
 }
 
+// LabelResponse represents a label response
 type LabelResponse struct {
 	Name           string      `json:"name"`
 	Description    string      `json:"description"`
@@ -45,14 +51,17 @@ type LabelResponse struct {
 	TotalExecutors int64       `json:"totalExecutors"`
 }
 
+// GetName gets the name for a label
 func (l *Label) GetName() string {
 	return l.Raw.Name
 }
 
+// GetNodes gets the nodes for a label
 func (l *Label) GetNodes() []LabelNode {
 	return l.Raw.Nodes
 }
 
+// Poll polls labels
 func (l *Label) Poll() (int, error) {
 	response, err := l.Jenkins.Requester.GetJSON(l.Base, l.Raw, nil)
 	if err != nil {

--- a/node.go
+++ b/node.go
@@ -18,6 +18,7 @@ import "errors"
 
 // Nodes
 
+// Computers represents a computer
 type Computers struct {
 	BusyExecutors  int             `json:"busyExecutors"`
 	Computers      []*NodeResponse `json:"computer"`
@@ -25,12 +26,14 @@ type Computers struct {
 	TotalExecutors int             `json:"totalExecutors"`
 }
 
+// Node represents a node
 type Node struct {
 	Raw     *NodeResponse
 	Jenkins *Jenkins
 	Base    string
 }
 
+// NodeResponse represents a node response
 type NodeResponse struct {
 	Actions     []interface{} `json:"actions"`
 	DisplayName string        `json:"displayName"`
@@ -79,6 +82,7 @@ type NodeResponse struct {
 	TemporarilyOffline bool          `json:"temporarilyOffline"`
 }
 
+// Info returns a node's info
 func (n *Node) Info() (*NodeResponse, error) {
 	_, err := n.Poll()
 	if err != nil {
@@ -87,10 +91,12 @@ func (n *Node) Info() (*NodeResponse, error) {
 	return n.Raw, nil
 }
 
+// GetName gets a node's name
 func (n *Node) GetName() string {
 	return n.Raw.DisplayName
 }
 
+// Delete deletes a node
 func (n *Node) Delete() (bool, error) {
 	resp, err := n.Jenkins.Requester.Post(n.Base+"/doDelete", nil, nil, nil)
 	if err != nil {
@@ -99,6 +105,7 @@ func (n *Node) Delete() (bool, error) {
 	return resp.StatusCode == 200, nil
 }
 
+// IsOnline returns if a node is online
 func (n *Node) IsOnline() (bool, error) {
 	_, err := n.Poll()
 	if err != nil {
@@ -107,6 +114,7 @@ func (n *Node) IsOnline() (bool, error) {
 	return !n.Raw.Offline, nil
 }
 
+// IsTemporarilyOffline returns if a node is temporarily offline or not
 func (n *Node) IsTemporarilyOffline() (bool, error) {
 	_, err := n.Poll()
 	if err != nil {
@@ -115,6 +123,7 @@ func (n *Node) IsTemporarilyOffline() (bool, error) {
 	return n.Raw.TemporarilyOffline, nil
 }
 
+// IsIdle returns if a node is idle
 func (n *Node) IsIdle() (bool, error) {
 	_, err := n.Poll()
 	if err != nil {
@@ -123,6 +132,7 @@ func (n *Node) IsIdle() (bool, error) {
 	return n.Raw.Idle, nil
 }
 
+// IsJnlpAgent returns if a node is a jnlp agent
 func (n *Node) IsJnlpAgent() (bool, error) {
 	_, err := n.Poll()
 	if err != nil {
@@ -131,6 +141,7 @@ func (n *Node) IsJnlpAgent() (bool, error) {
 	return n.Raw.JnlpAgent, nil
 }
 
+// SetOnline sets a node online
 func (n *Node) SetOnline() (bool, error) {
 	_, err := n.Poll()
 
@@ -149,6 +160,7 @@ func (n *Node) SetOnline() (bool, error) {
 	return true, nil
 }
 
+// SetOffline sets a node offline
 func (n *Node) SetOffline(options ...interface{}) (bool, error) {
 	if !n.Raw.Offline {
 		return n.ToggleTemporarilyOffline(options...)
@@ -156,6 +168,7 @@ func (n *Node) SetOffline(options ...interface{}) (bool, error) {
 	return false, errors.New("Node already Offline")
 }
 
+// ToggleTemporarilyOffline toggles a node offline temporarily
 func (n *Node) ToggleTemporarilyOffline(options ...interface{}) (bool, error) {
 	state_before, err := n.IsTemporarilyOffline()
 	if err != nil {
@@ -179,6 +192,7 @@ func (n *Node) ToggleTemporarilyOffline(options ...interface{}) (bool, error) {
 	return true, nil
 }
 
+// Poll polls a node
 func (n *Node) Poll() (int, error) {
 	response, err := n.Jenkins.Requester.GetJSON(n.Base, n.Raw, nil)
 	if err != nil {
@@ -187,6 +201,7 @@ func (n *Node) Poll() (int, error) {
 	return response.StatusCode, nil
 }
 
+// LaunchNodeBySSH launches a node by SSH
 func (n *Node) LaunchNodeBySSH() (int, error) {
 	qr := map[string]string{
 		"json":   "",
@@ -199,6 +214,7 @@ func (n *Node) LaunchNodeBySSH() (int, error) {
 	return response.StatusCode, nil
 }
 
+// Disconnect disconnects a node
 func (n *Node) Disconnect() (int, error) {
 	qr := map[string]string{
 		"offlineMessage": "",
@@ -212,6 +228,7 @@ func (n *Node) Disconnect() (int, error) {
 	return response.StatusCode, nil
 }
 
+// GetLogText gets a node's log
 func (n *Node) GetLogText() (string, error) {
 	var log string
 

--- a/plugin.go
+++ b/plugin.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 )
 
+// Plugins represents Plugins
 type Plugins struct {
 	Jenkins *Jenkins
 	Raw     *PluginResponse
@@ -25,10 +26,12 @@ type Plugins struct {
 	Depth   int
 }
 
+// PluginResponse represents a plugin response from jenkins
 type PluginResponse struct {
 	Plugins []Plugin `json:"plugins"`
 }
 
+// Plugin represents a plugin
 type Plugin struct {
 	Active        bool        `json:"active"`
 	BackupVersion interface{} `json:"backupVersion"`
@@ -50,10 +53,12 @@ type Plugin struct {
 	Version             string `json:"version"`
 }
 
+// Count returns the count of plugins
 func (p *Plugins) Count() int {
 	return len(p.Raw.Plugins)
 }
 
+// Contains returns if a plugin by name
 func (p *Plugins) Contains(name string) *Plugin {
 	for _, p := range p.Raw.Plugins {
 		if p.LongName == name || p.ShortName == name {
@@ -63,6 +68,7 @@ func (p *Plugins) Contains(name string) *Plugin {
 	return nil
 }
 
+// Poll polls a plugin
 func (p *Plugins) Poll() (int, error) {
 	qr := map[string]string{
 		"depth": strconv.Itoa(p.Depth),

--- a/queue.go
+++ b/queue.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 )
 
+// Queue represents a queue
 type Queue struct {
 	Jenkins *Jenkins
 	Raw     *queueResponse
@@ -28,6 +29,7 @@ type queueResponse struct {
 	Items []taskResponse
 }
 
+// Task represents a task
 type Task struct {
 	Raw     *taskResponse
 	Jenkins *Jenkins
@@ -58,6 +60,7 @@ type generalAction struct {
 	Parameters []parameter
 }
 
+// Tasks gets tasks on a queue
 func (q *Queue) Tasks() []*Task {
 	tasks := make([]*Task, len(q.Raw.Items))
 	for i, t := range q.Raw.Items {
@@ -66,6 +69,7 @@ func (q *Queue) Tasks() []*Task {
 	return tasks
 }
 
+// GetTaskById gets a task by id
 func (q *Queue) GetTaskById(id int64) *Task {
 	for _, t := range q.Raw.Items {
 		if t.ID == id {
@@ -75,6 +79,7 @@ func (q *Queue) GetTaskById(id int64) *Task {
 	return nil
 }
 
+// GetTasksForJob gets tasks for a job
 func (q *Queue) GetTasksForJob(name string) []*Task {
 	tasks := make([]*Task, 0)
 	for _, t := range q.Raw.Items {
@@ -85,11 +90,13 @@ func (q *Queue) GetTasksForJob(name string) []*Task {
 	return tasks
 }
 
+// CancelTask cancels a task by id
 func (q *Queue) CancelTask(id int64) (bool, error) {
 	task := q.GetTaskById(id)
 	return task.Cancel()
 }
 
+// Cancel cancels the current task
 func (t *Task) Cancel() (bool, error) {
 	qr := map[string]string{
 		"id": strconv.FormatInt(t.Raw.ID, 10),
@@ -101,14 +108,17 @@ func (t *Task) Cancel() (bool, error) {
 	return response.StatusCode == 200, nil
 }
 
+// GetJob gets the job associated with a task
 func (t *Task) GetJob() (*Job, error) {
 	return t.Jenkins.GetJob(t.Raw.Task.Name)
 }
 
+// GetWhy gets the why a task was queued
 func (t *Task) GetWhy() string {
 	return t.Raw.Why
 }
 
+// GetParameters gets a task's parameters
 func (t *Task) GetParameters() []parameter {
 	for _, a := range t.Raw.Actions {
 		if a.Parameters != nil {
@@ -118,6 +128,7 @@ func (t *Task) GetParameters() []parameter {
 	return nil
 }
 
+// GetCauses returns a task's causes
 func (t *Task) GetCauses() []map[string]interface{} {
 	for _, a := range t.Raw.Actions {
 		if a.Causes != nil {
@@ -127,6 +138,7 @@ func (t *Task) GetCauses() []map[string]interface{} {
 	return nil
 }
 
+// Poll polls the queue
 func (q *Queue) Poll() (int, error) {
 	response, err := q.Jenkins.Requester.GetJSON(q.Base, q.Raw, nil)
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -25,6 +25,8 @@ func makeJson(data interface{}) string {
 }
 
 // Check if element is present in a slice.
+// deadcode
+/*
 func inSlice(a string, list []string) bool {
 	for _, b := range list {
 		if b == a {
@@ -33,3 +35,4 @@ func inSlice(a string, list []string) bool {
 	}
 	return false
 }
+*/

--- a/views.go
+++ b/views.go
@@ -19,12 +19,14 @@ import (
 	"strconv"
 )
 
+// View represents a view
 type View struct {
 	Raw     *ViewResponse
 	Jenkins *Jenkins
 	Base    string
 }
 
+// ViewResponse represents a View JSON response
 type ViewResponse struct {
 	Description string        `json:"description"`
 	Jobs        []InnerJob    `json:"jobs"`
@@ -34,14 +36,19 @@ type ViewResponse struct {
 }
 
 var (
-	LIST_VIEW      = "hudson.model.ListView"
-	NESTED_VIEW    = "hudson.plugins.nested_view.NestedView"
-	MY_VIEW        = "hudson.model.MyView"
+	// LIST_VIEW is the string matching list view
+	LIST_VIEW = "hudson.model.ListView"
+	// NESTED_VIEW is the string matching nested view
+	NESTED_VIEW = "hudson.plugins.nested_view.NestedView"
+	// MY_VIEW is the string matching a personal view
+	MY_VIEW = "hudson.model.MyView"
+	// DASHBOARD_VIEW is the string matching a dashboard view
 	DASHBOARD_VIEW = "hudson.plugins.view.dashboard.Dashboard"
-	PIPELINE_VIEW  = "au.com.centrumsystems.hudson.plugin.buildpipeline.BuildPipelineView"
+	// PIPELINE_VIEW is the string matching a pipeline view
+	PIPELINE_VIEW = "au.com.centrumsystems.hudson.plugin.buildpipeline.BuildPipelineView"
 )
 
-// Returns True if successfully added Job, otherwise false
+// AddJob adds a job. Returns True if successfully added Job, otherwise false
 func (v *View) AddJob(name string) (bool, error) {
 	url := "/addJobToView"
 	qr := map[string]string{"name": name}
@@ -55,7 +62,7 @@ func (v *View) AddJob(name string) (bool, error) {
 	return false, errors.New(strconv.Itoa(resp.StatusCode))
 }
 
-// Returns True if successfully deleted Job, otherwise false
+// DeleteJob deletes a job. Returns True if successfully deleted Job, otherwise false
 func (v *View) DeleteJob(name string) (bool, error) {
 	url := "/removeJobFromView"
 	qr := map[string]string{"name": name}
@@ -69,22 +76,27 @@ func (v *View) DeleteJob(name string) (bool, error) {
 	return false, errors.New(strconv.Itoa(resp.StatusCode))
 }
 
+// GetDescription gets a view's description
 func (v *View) GetDescription() string {
 	return v.Raw.Description
 }
 
+// GetJobs gets a view's jobs
 func (v *View) GetJobs() []InnerJob {
 	return v.Raw.Jobs
 }
 
+// GetName gets a view's name
 func (v *View) GetName() string {
 	return v.Raw.Name
 }
 
+//GetUrl gets a view's url
 func (v *View) GetUrl() string {
 	return v.Raw.URL
 }
 
+// Poll polls a view
 func (v *View) Poll() (int, error) {
 	response, err := v.Jenkins.Requester.GetJSON(v.Base, v.Raw, nil)
 	if err != nil {


### PR DESCRIPTION
This also fixes the broken json decoding mention in #93 
I didn't fix EVERYTHING specified by gometalinter because it would cause massive api breakage. 

The remaining complaining from gometalinter is mostly around spelling and whatnot.

I run like so:
`gometalinter --disable-all --enable=vet --enable=vetshadow --enable=golint --enable=ineffassign --enable=goconst --enable=deadcode
--enable=gosimple --enable=errcheck --enable=goimports --tests .`

and the current output is:
```
job.go:467:14:warning: 2 other occurrence(s) of "/build" found in: job.go:524:10 job.go:535:10 (goconst)
job.go:524:10:warning: 2 other occurrence(s) of "/build" found in: job.go:467:14 job.go:535:10 (goconst)
job.go:535:10:warning: 2 other occurrence(s) of "/build" found in: job.go:467:14 job.go:524:10 (goconst)
build.go:60:2:warning: struct field AbsoluteUrl should be AbsoluteURL (golint)
build.go:75:2:warning: struct field UrlName should be URLName (golint)
build.go:123:5:warning: struct field AbsoluteUrl should be AbsoluteURL (golint)
build.go:127:4:warning: struct field CommitId should be CommitID (golint)
build.go:152:2:warning: struct field QueueId should be QueueID (golint)
build.go:161:3:warning: struct field Url should be URL (golint)
build.go:173:30:warning: exported method GetActions returns unexported type []gojenkins.generalObj, which can be annoying to use (golint)
build.go:178:17:warning: method GetUrl should be GetURL (golint)
build.go:207:31:warning: exported method GetCulprits returns unexported type []gojenkins.culprit, which can be annoying to use (golint)
build.go:246:33:warning: exported method GetParameters returns unexported type []gojenkins.parameter, which can be annoying to use (golint)
build.go:280:10:warning: range var buildId should be buildID (golint)
build.go:337:1:warning: comment on exported method Build.GetUpstreamBuildNumber should be of the form "GetUpstreamBuildNumber ..." (golint)
build_history.go:100:6:warning: func hasCssClass should be hasCSSClass (golint)
constants.go:4:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
constants.go:4:2:warning: exported const STATUS_FAIL should have comment (or a comment on this block) or be unexported (golint)
constants.go:5:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
constants.go:6:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
constants.go:7:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
constants.go:8:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
constants.go:9:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
constants.go:10:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
constants.go:11:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
constants.go:12:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
constants.go:13:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
constants.go:14:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
fingerprint.go:26:2:warning: struct field Id should be ID (golint)
fingerprint.go:85:33:warning: exported method GetInfo returns unexported type *gojenkins.fingerPrintResponse, which can be annoying to use (golint)
jenkins.go:77:4:warning: var proxyUrl should be proxyURL (golint)
jenkins.go:175:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
jenkins.go:210:1:warning: comment on exported method Jenkins.CreateFolder should be of the form "CreateFolder ..." (golint)
jenkins.go:222:1:warning: comment on exported method Jenkins.CreateJobInFolder should be of the form "CreateJobInFolder ..." (golint)
jenkins.go:236:1:warning: comment on exported method Jenkins.CreateJob should be of the form "CreateJob ..." (golint)
jenkins.go:345:29:warning: method parameter parentId should be parentID (golint)
jenkins.go:345:46:warning: method parameter childId should be childID (golint)
jenkins.go:448:19:warning: method GetQueueUrl should be GetQueueURL (golint)
jenkins.go:453:47:warning: exported method GetArtifactData returns unexported type *gojenkins.fingerPrintResponse, which can be annoying to use (golint)
jenkins.go:480:1:warning: comment on exported method Jenkins.ValidateFingerPrint should be of the form "ValidateFingerPrint ..." (golint)
jenkins_test.go:26:2:warning: don't use underscores in Go names; var job_data should be jobData (golint)
jenkins_test.go:85:2:warning: don't use underscores in Go names; var list_view should be listView (golint)
jenkins_test.go:91:2:warning: don't use underscores in Go names; var my_view should be myView (golint)
jenkins_test.go:213:2:warning: don't use underscores in Go names; var job_data should be jobData (golint)
job.go:44:2:warning: struct field Url should be URL (golint)
job.go:74:3:warning: struct field IconUrl should be IconURL (golint)
node.go:68:3:warning: don't use underscores in Go names; struct field Hudson_NodeMonitors_ArchitectureMonitor should be HudsonNodeMonitorsArchitectureMonitor (golint)
node.go:69:3:warning: don't use underscores in Go names; struct field Hudson_NodeMonitors_ClockMonitor should be HudsonNodeMonitorsClockMonitor (golint)
node.go:70:3:warning: don't use underscores in Go names; struct field Hudson_NodeMonitors_DiskSpaceMonitor should be HudsonNodeMonitorsDiskSpaceMonitor (golint)
node.go:71:3:warning: don't use underscores in Go names; struct field Hudson_NodeMonitors_ResponseTimeMonitor should be HudsonNodeMonitorsResponseTimeMonitor (golint)
node.go:74:3:warning: don't use underscores in Go names; struct field Hudson_NodeMonitors_SwapSpaceMonitor should be HudsonNodeMonitorsSwapSpaceMonitor (golint)
node.go:75:3:warning: don't use underscores in Go names; struct field Hudson_NodeMonitors_TemporarySpaceMonitor should be HudsonNodeMonitorsTemporarySpaceMonitor (golint)
node.go:173:2:warning: don't use underscores in Go names; var state_before should be stateBefore (golint)
node.go:185:2:warning: don't use underscores in Go names; var new_state should be newState (golint)
queue.go:73:17:warning: method GetTaskById should be GetTaskByID (golint)
queue.go:122:32:warning: exported method GetParameters returns unexported type []gojenkins.parameter, which can be annoying to use (golint)
utils.go:19:6:warning: func makeJson should be makeJSON (golint)
views.go:40:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
views.go:42:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
views.go:44:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
views.go:46:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
views.go:48:2:warning: don't use ALL_CAPS in Go names; use CamelCase (golint)
views.go:95:16:warning: method GetUrl should be GetURL (golint)
build.go:227:28:warning: error return value not checked (b.Jenkins.Requester.GetXML(url, &content, nil)) (errcheck)
build.go:315:8:warning: error return value not checked (b.Poll(3)) (errcheck)
build.go:383:17:warning: error return value not checked (result[i].Poll()) (errcheck)
jenkins.go:259:15:warning: error return value not checked (jobObj.Rename(name)) (errcheck)
jenkins_test.go:62:20:warning: error return value not checked (item.InvokeSimple(map[string]string{"param1": "param1"})) (errcheck)
jenkins_test.go:63:12:warning: error return value not checked (item.Poll()) (errcheck)
jenkins_test.go:246:22:warning: error return value not checked (jenkins.GetAllJobs()) (errcheck)
jenkins_test.go:247:23:warning: error return value not checked (jenkins.GetAllViews()) (errcheck)
jenkins_test.go:248:23:warning: error return value not checked (jenkins.GetAllNodes()) (errcheck)
job.go:359:9:warning: error return value not checked (j.Poll()) (errcheck)
job.go:393:9:warning: error return value not checked (j.Poll()) (errcheck)
request.go:221:37:warning: error return value not checked (json.NewDecoder(ar.Payload).Decode(&params)) (errcheck)
request.go:288:39:warning: error return value not checked (json.NewDecoder(response.Body).Decode(responseStruct)) (errcheck)
```