### PR TITLE
fix: check whether the username is "" is needed.

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -521,7 +521,7 @@ func CreateJenkins(client *http.Client, base string, auth ...interface{}) *Jenki
 	if j.Requester.Client == nil {
 		j.Requester.Client = http.DefaultClient
 	}
-	if len(auth) == 2 {
+	if len(auth) == 2 && auth[0] != "" {
 		j.Requester.BasicAuth = &BasicAuth{Username: auth[0].(string), Password: auth[1].(string)}
 	}
 	return j


### PR DESCRIPTION
- Check whether the username is "" is needed, as we may use Jenkins without any user.

What happened: 

- When I use Jenkins without username and password, it comes the error 401. With the review of code, I found it can create Jenkins Instance successfully, however, when it goes to create a job, it failed.

![image](https://user-images.githubusercontent.com/29789939/31869652-06c3ad46-b76f-11e7-800e-b00bc9eaa423.png)

