### PR TITLE
adding QueueBuildJob() that queues a job even if it is currently running

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -250,7 +250,18 @@ func (j *Jenkins) BuildJob(name string, options ...interface{}) (int64, error) {
 	if len(options) > 0 {
 		params, _ = options[0].(map[string]string)
 	}
-	return job.InvokeSimple(params)
+	return job.InvokeSimple(params, false)
+}
+
+// Queue a job.
+// First parameter job name, second parameter is optional Build parameters.
+func (j *Jenkins) QueueBuildJob(name string, options ...interface{}) (int64, error) {
+	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + name}
+	var params map[string]string
+	if len(options) > 0 {
+		params, _ = options[0].(map[string]string)
+	}
+	return job.InvokeSimple(params, true)
 }
 
 func (j *Jenkins) GetNode(name string) (*Node, error) {

--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -59,7 +59,7 @@ func TestCreateNodes(t *testing.T) {
 func TestCreateBuilds(t *testing.T) {
 	jobs, _ := jenkins.GetAllJobs()
 	for _, item := range jobs {
-		item.InvokeSimple(map[string]string{"param1": "param1"})
+		item.InvokeSimple(map[string]string{"param1": "param1"}, false)
 		item.Poll()
 		isQueued, _ := item.IsQueued()
 		assert.Equal(t, true, isQueued)

--- a/job.go
+++ b/job.go
@@ -397,14 +397,16 @@ func (j *Job) HasQueuedBuild() {
 	panic("Not Implemented yet")
 }
 
-func (j *Job) InvokeSimple(params map[string]string) (int64, error) {
-	isQueued, err := j.IsQueued()
-	if err != nil {
-		return 0, err
-	}
-	if isQueued {
-		Error.Printf("%s is already running", j.GetName())
-		return 0, nil
+func (j *Job) InvokeSimple(params map[string]string, queueJob bool) (int64, error) {
+	if (!queueJob) {
+		isQueued, err := j.IsQueued()
+		if err != nil {
+			return 0, err
+		}
+		if isQueued {
+			Error.Printf("%s is already running", j.GetName())
+			return 0, nil
+		}
 	}
 
 	endpoint := "/build"


### PR DESCRIPTION
Useful for jobs that take parameters. ie. we have a job that takes the parameters artifact name and version that then promotes that artifact to our testing and release servers.