### PR TITLE
Add call for getting queue item

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -409,6 +409,20 @@ func (j *Jenkins) GetQueueUrl() string {
 	return "/queue"
 }
 
+// GetQueueItem returns a single queue Task
+func (j *Jenkins) GetQueueItem(id int64) (*Task, error) {
+	t := &Task{Raw: new(taskResponse), Jenkins: j, Base: j.getQueueItemURL(id)}
+	_, err := t.Poll()
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+func (j *Jenkins) getQueueItemURL(id int64) string {
+	return fmt.Sprintf("/queue/item/%d", id)
+}
+
 // Get Artifact data by Hash
 func (j *Jenkins) GetArtifactData(id string) (*FingerPrintResponse, error) {
 	fp := FingerPrint{Jenkins: j, Base: "/fingerprint/", Id: id, Raw: new(FingerPrintResponse)}

--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	jenkins *Jenkins
+	queueID int64
 )
 
 func TestInit(t *testing.T) {
@@ -67,7 +68,7 @@ func TestDeleteNodes(t *testing.T) {
 func TestCreateBuilds(t *testing.T) {
 	jobs, _ := jenkins.GetAllJobs()
 	for _, item := range jobs {
-		item.InvokeSimple(map[string]string{"param1": "param1"})
+		queueID, _ = item.InvokeSimple(map[string]string{"param1": "param1"})
 		item.Poll()
 		isQueued, _ := item.IsQueued()
 		assert.Equal(t, true, isQueued)
@@ -76,6 +77,16 @@ func TestCreateBuilds(t *testing.T) {
 
 		assert.True(t, (len(builds) > 0))
 
+	}
+}
+
+func TestGetQueueItem(t *testing.T) {
+	task, err := jenkins.GetQueueItem(queueID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Raw == nil || task.Raw.ID != queueID {
+		t.Fatal()
 	}
 }
 

--- a/queue.go
+++ b/queue.go
@@ -32,6 +32,7 @@ type Task struct {
 	Raw     *taskResponse
 	Jenkins *Jenkins
 	Queue   *Queue
+	Base    string
 }
 
 type taskResponse struct {
@@ -49,8 +50,12 @@ type taskResponse struct {
 		Name  string `json:"name"`
 		URL   string `json:"url"`
 	} `json:"task"`
-	URL string `json:"url"`
-	Why string `json:"why"`
+	URL        string `json:"url"`
+	Why        string `json:"why"`
+	Executable struct {
+		Number int64  `json:"number"`
+		URL    string `json:"url"`
+	} `json:"executable"`
 }
 
 type generalAction struct {
@@ -129,6 +134,14 @@ func (t *Task) GetCauses() []map[string]interface{} {
 
 func (q *Queue) Poll() (int, error) {
 	response, err := q.Jenkins.Requester.GetJSON(q.Base, q.Raw, nil)
+	if err != nil {
+		return 0, err
+	}
+	return response.StatusCode, nil
+}
+
+func (t *Task) Poll() (int, error) {
+	response, err := t.Jenkins.Requester.GetJSON(t.Base, t.Raw, nil)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Current call GetQueue() is not enough, because it is possible that build is no longer in queue when the call happens - builds are removed from overall queue as soon as the build starts. However it is still possible to retrieve item from the queue by getting single task by ID. This task also has Executable field with build ID when the build is started and it is possible to get the build ID from queue task. 