### PR TITLE
Support RunParameterValue in build parameters

### DIFF
--- a/build.go
+++ b/build.go
@@ -32,8 +32,11 @@ type Build struct {
 }
 
 type parameter struct {
-	Name  string
-	Value string
+	Class   string `json:"_class"`
+	Name    string
+	Value   string
+	JobName string
+	Number  string
 }
 
 type branch struct {


### PR DESCRIPTION
RunParameterValue inherits from ParameterValue and introduces two
additional values to parameters -- jobName and build number. Add those
fields and the class name to parameters.