### PR TITLE
New CSRF security: all POST requests are failing with `403 Forbidden`

### DIFF
--- a/request.go
+++ b/request.go
@@ -65,6 +65,7 @@ func (r *Requester) SetCrumb(ar *APIRequest) error {
 
 	if response.StatusCode == 200 && crumbData["crumbRequestField"] != "" {
 		ar.SetHeader(crumbData["crumbRequestField"], crumbData["crumb"])
+		ar.SetHeader("Cookie", response.Header.Get("set-cookie"))
 	}
 
 	return nil


### PR DESCRIPTION
Jenkins 2.192 contains some security fixes which are breaking all POST requests right now.

*See announcement:*
https://jenkins.io/security/advisory/2019-08-28/#SECURITY-1491

-> The Crumb token needs to be fetched within same session (which is part of the Cookies). Else it would be a anonymous requests which is blocked now -> `403 Forbidden`


See related PR in ansible/ansible
https://github.com/ansible/ansible/pull/61713/files