### PR TITLE
trim suffix blank space

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -560,6 +560,7 @@ func (j *Jenkins) Poll() (int, error) {
 // After creating an instance call init method.
 func CreateJenkins(client *http.Client, base string, auth ...interface{}) *Jenkins {
 	j := &Jenkins{}
+	base = strings.TrimSuffix(base, " ")
 	if strings.HasSuffix(base, "/") {
 		base = base[:len(base)-1]
 	}


### PR DESCRIPTION
When I type extra blank space in base jenkins' host coincidentally, It takes long time to debug. So maybe I would trim suffix blank space in base host.