### PR TITLE
Let's add timeout to jenkins client

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Basic Authentication
@@ -525,7 +526,9 @@ func CreateJenkins(client *http.Client, base string, auth ...interface{}) *Jenki
 	j.Server = base
 	j.Requester = &Requester{Base: base, SslVerify: true, Client: client}
 	if j.Requester.Client == nil {
-		j.Requester.Client = http.DefaultClient
+		j.Requester.Client = &http.Client{
+			Timeout: 5 * time.Second,
+		}
 	}
 	if len(auth) == 2 {
 		j.Requester.BasicAuth = &BasicAuth{Username: auth[0].(string), Password: auth[1].(string)}


### PR DESCRIPTION
This relies on the default http client which does not have a timeout set, let's add a reasonable timeout