### PR TITLE
Improvements on the API calls

### DIFF
--- a/build.go
+++ b/build.go
@@ -68,6 +68,16 @@ type generalObj struct {
 	MercurialNodeName       string                   `json:"mercurialNodeName"`
 	MercurialRevisionNumber string                   `json:"mercurialRevisionNumber"`
 	Subdir                  interface{}              `json:"subdir"`
+	Class                   string                   `json:"_class"`
+	BlockedDurationMillis   int64                    `json:"blockedDurationMillis"`
+	BlockedTimeMillis       int64                    `json:"blockedTimeMillis"`
+	BuildableTimeMillis     int64                    `json:"buildableTimeMillis"`
+	BuildingDurationMillis  int64                    `json:"buildingDurationMillis"`
+	ExecutingTimeMillis     int64                    `json:"executingTimeMillis"`
+	ExecutorUtilization     int64                    `json:"executorUtilization"`
+	SubTaskCount            int64                    `json:"subTaskCount"`
+	WaitingDurationMillis   int64                    `json:"waitingDurationMillis"`
+	WaitingTimeMillis       int64                    `json:"waitingTimeMillis"`
 	TotalCount              int64
 	UrlName                 string
 }

--- a/request.go
+++ b/request.go
@@ -64,6 +64,11 @@ func (r *Requester) SetCrumb(ar *APIRequest) error {
 	response, _ := r.GetJSON("/crumbIssuer/api/json", &crumbData, nil)
 
 	if response.StatusCode == 200 && crumbData["crumbRequestField"] != "" {
+		var cookies []string
+		for _, value := range response.Cookies() {
+			cookies = append(cookies, fmt.Sprintf("%s=%s", value.Name, value.Value))
+		}
+		ar.SetHeader("Cookie", strings.Join(cookies, ";"))
 		ar.SetHeader(crumbData["crumbRequestField"], crumbData["crumb"])
 		ar.SetHeader("Cookie", response.Header.Get("set-cookie"))
 	}


### PR DESCRIPTION
- Adding further fields to the Job API to gather details on the job queueing and execution time
- Setting Cookies header to account for the Crumbs setup, otherwise API calls will break (credit to @nattymachado)