### PR TITLE
Support build a project under the folder

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -265,6 +265,9 @@ func (j *Jenkins) DeleteJob(name string) (bool, error) {
 // Invoke a job.
 // First parameter job name, second parameter is optional Build parameters.
 func (j *Jenkins) BuildJob(name string, options ...interface{}) (int64, error) {
+	// support with folder
+	name = strings.Replace(name, "/", "/job/", -1)
+
 	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + name}
 	var params map[string]string
 	if len(options) > 0 {


### PR DESCRIPTION
as normal project name cannot contains with '/', so we can split folder names and project name with '/'.

example group with folder name: /group1/subgroup2/job3

jenkins api url is /job/group1/job/subgroup2/job/job3

invoke build as code below
```jenkins.BuildJob("/group1/subgroup2/job3")```

#125 