### PR TITLE
Support Job Copy in Folder

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -248,6 +248,9 @@ func (j *Jenkins) RenameJob(job string, name string) *Job {
 // Create a copy of a job.
 // First parameter Name of the job to copy from, Second parameter new job name.
 func (j *Jenkins) CopyJob(copyFrom string, newName string) (*Job, error) {
+	// support folder
+	copyFrom := strings.Replace(copyFrom, "/", "/job/", -1)
+
 	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + copyFrom}
 	_, err := job.Poll()
 	if err != nil {


### PR DESCRIPTION
this patch support job copy from/to in folder. (destination folder must be exists.)

example code 
```
jenkins.CopyJob("/group1/subgroup2/job3", "newJob") 
jenkins.CopyJob("/group1/subgroup2/job3", "/newGroup1/newGroup2/newJob") 
jenkins.CopyJob("job3", "/newGroup1/newJob") 
jenkins.CopyJob("job3", "newJob") 
```
