### PR TITLE
Handle non-string parameters like booleanParam

### DIFF
--- a/build.go
+++ b/build.go
@@ -33,7 +33,7 @@ type Build struct {
 
 type parameter struct {
 	Name  string
-	Value string
+	Value interface{}
 }
 
 type branch struct {


### PR DESCRIPTION
Jenkins supports more than strings here; before this change,
non-stringParam values came back as empty strings (since they fail the
cast back to string).