### PR TITLE
  Add context in functions to make debugging easier and Add GetBuildFromQueueID() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,59 +26,41 @@ These are some of the features that are currently implemented:
 
 ```go
 
-import "github.com/bndr/gojenkins"
+import (
+  "github.com/bndr/gojenkins"
+  "context"
+  "time"
+  "fmt"
+)
 
+ctx := context.Background()
 jenkins := gojenkins.CreateJenkins(nil, "http://localhost:8080/", "admin", "admin")
 // Provide CA certificate if server is using self-signed certificate
 // caCert, _ := ioutil.ReadFile("/tmp/ca.crt")
 // jenkins.Requester.CACert = caCert
-_, err := jenkins.Init()
+_, err := jenkins.Init(ctx)
 
 
 if err != nil {
   panic("Something Went Wrong")
 }
 
-build, err := jenkins.GetJob("job_name")
+queueid, err := jenkins.BuildJob(ctx, "#jobname")
 if err != nil {
-  panic("Job Does Not Exist")
+  panic(err)
+}
+build, err := jenkins.GetBuildFromQueueID(ctx, queueid)
+if err != nil {
+  panic(err)
 }
 
-lastSuccessBuild, err := build.GetLastSuccessfulBuild()
-if err != nil {
-  panic("Last SuccessBuild does not exist")
+// Wait for build to finish
+for build.IsRunning(ctx) {
+  time.Sleep(5000 * time.Millisecond)
+  build.Poll(ctx)
 }
 
-duration := lastSuccessBuild.GetDuration()
-
-job, err := jenkins.GetJob("jobname")
-
-if err != nil {
-  panic("Job does not exist")
-}
-
-job.Rename("SomeotherJobName")
-
-configString := `<?xml version='1.0' encoding='UTF-8'?>
-<project>
-  <actions/>
-  <description></description>
-  <keepDependencies>false</keepDependencies>
-  <properties/>
-  <scm class="hudson.scm.NullSCM"/>
-  <canRoam>true</canRoam>
-  <disabled>false</disabled>
-  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
-  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <triggers class="vector"/>
-  <concurrentBuild>false</concurrentBuild>
-  <builders/>
-  <publishers/>
-  <buildWrappers/>
-</project>`
-
-j.CreateJob(configString, "someNewJobsName")
-
+fmt.Printf("build number %d with result: %v\n", build.GetBuildNumber(), build.GetResult())
 
 ```
 
@@ -90,20 +72,20 @@ For all of the examples below first create a jenkins object
 ```go
 import "github.com/bndr/gojenkins"
 
-jenkins, _ := gojenkins.CreateJenkins(nil, "http://localhost:8080/", "admin", "admin").Init()
+jenkins, _ := gojenkins.CreateJenkins(nil, "http://localhost:8080/", "admin", "admin").Init(ctx)
 ```
 
 or if you don't need authentication:
 
 ```go
-jenkins, _ := gojenkins.CreateJenkins(nil, "http://localhost:8080/").Init()
+jenkins, _ := gojenkins.CreateJenkins(nil, "http://localhost:8080/").Init(ctx)
 ```
 
 you can also specify your own `http.Client` (for instance, providing your own SSL configurations):
 
 ```go
 client := &http.Client{ ... }
-jenkins, := gojenkins.CreateJenkins(client, "http://localhost:8080/").Init()
+jenkins, := gojenkins.CreateJenkins(client, "http://localhost:8080/").Init(ctx)
 ```
 
 By default, `gojenkins` will use the `http.DefaultClient` if none is passed into the `CreateJenkins()`
@@ -112,13 +94,13 @@ function.
 ### Check Status of all nodes
 
 ```go
-nodes := jenkins.GetAllNodes()
+nodes := jenkins.GetAllNodes(ctx)
 
 for _, node := range nodes {
 
   // Fetch Node Data
-  node.Poll()
-	if node.IsOnline() {
+  node.Poll(ctx)
+	if node.IsOnline(ctx) {
 		fmt.Println("Node is Online")
 	}
 }
@@ -129,7 +111,7 @@ for _, node := range nodes {
 
 ```go
 jobName := "someJob"
-builds, err := jenkins.GetAllBuildIds(jobName)
+builds, err := jenkins.GetAllBuildIds(ctx, jobName)
 
 if err != nil {
   panic(err)
@@ -137,26 +119,26 @@ if err != nil {
 
 for _, build := range builds {
   buildId := build.Number
-  data, err := jenkins.GetBuild(jobName, buildId)
+  data, err := jenkins.GetBuild(ctx, jobName, buildId)
 
   if err != nil {
     panic(err)
   }
 
-	if "SUCCESS" == data.GetResult() {
+	if "SUCCESS" == data.GetResult(ctx) {
 		fmt.Println("This build succeeded")
 	}
 }
 
 // Get Last Successful/Failed/Stable Build for a Job
-job, err := jenkins.GetJob("someJob")
+job, err := jenkins.GetJob(ctx, "someJob")
 
 if err != nil {
   panic(err)
 }
 
-job.GetLastSuccessfulBuild()
-job.GetLastStableBuild()
+job.GetLastSuccessfulBuild(ctx)
+job.GetLastStableBuild(ctx)
 
 ```
 
@@ -164,10 +146,10 @@ job.GetLastStableBuild()
 
 ```go
 
-tasks := jenkins.GetQueue()
+tasks := jenkins.GetQueue(ctx)
 
 for _, task := range tasks {
-	fmt.Println(task.GetWhy())
+	fmt.Println(task.GetWhy(ctx))
 }
 
 ```
@@ -176,13 +158,13 @@ for _, task := range tasks {
 
 ```go
 
-view, err := jenkins.CreateView("test_view", gojenkins.LIST_VIEW)
+view, err := jenkins.CreateView(ctx, "test_view", gojenkins.LIST_VIEW)
 
 if err != nil {
   panic(err)
 }
 
-status, err := view.AddJob("jobName")
+status, err := view.AddJob(ctx, "jobName")
 
 if status != nil {
   fmt.Println("Job has been added to view")
@@ -195,13 +177,13 @@ if status != nil {
 ```go
 
 // Create parent folder
-pFolder, err := jenkins.CreateFolder("parentFolder")
+pFolder, err := jenkins.CreateFolder(ctx, "parentFolder")
 if err != nil {
   panic(err)
 }
 
 // Create child folder in parent folder
-cFolder, err := jenkins.CreateFolder("childFolder", pFolder.GetName())
+cFolder, err := jenkins.CreateFolder(ctx, "childFolder", pFolder.GetName())
 if err != nil {
   panic(err)
 }
@@ -225,7 +207,7 @@ configString := `<?xml version='1.0' encoding='UTF-8'?>
   <buildWrappers/>
 </project>`
 
-job, err := jenkins.CreateJobInFolder(configString, "jobInFolder", pFolder.GetName(), cFolder.GetName())
+job, err := jenkins.CreateJobInFolder(ctx, configString, "jobInFolder", pFolder.GetName(), cFolder.GetName())
 if err != nil {
   panic(err)
 }
@@ -240,9 +222,9 @@ if job != nil {
 
 ```go
 
-job, _ := jenkins.GetJob("job")
-build, _ := job.GetBuild(1)
-artifacts := build.GetArtifacts()
+job, _ := jenkins.GetJob(ctx, "job")
+build, _ := job.GetBuild(ctx, 1)
+artifacts := build.GetArtifacts(ctx)
 
 for _, a := range artifacts {
 	a.SaveToDir("/tmp")
@@ -254,10 +236,10 @@ for _, a := range artifacts {
 
 ```go
 
-job, _ := jenkins.GetJob("job")
+job, _ := jenkins.GetJob(ctx, "job")
 job.Poll()
 
-build, _ := job.getBuild(1)
+build, _ := job.getBuild(ctx, 1)
 build.Poll()
 
 ```

--- a/artifact.go
+++ b/artifact.go
@@ -55,7 +55,7 @@ func (a Artifact) Save(ctx context.Context, path string) (bool, error) {
 	data, err := a.GetData(ctx)
 
 	if err != nil {
-		return false, errors.New("no Data received, not saving file")
+		return false, errors.New("No data received, not saving file")
 	}
 
 	if _, err = os.Stat(path); err == nil {

--- a/artifact.go
+++ b/artifact.go
@@ -15,6 +15,7 @@
 package gojenkins
 
 import (
+	"context"
 	"crypto/md5"
 	"errors"
 	"fmt"
@@ -33,9 +34,9 @@ type Artifact struct {
 }
 
 // Get raw byte data of Artifact
-func (a Artifact) GetData() ([]byte, error) {
+func (a Artifact) GetData(ctx context.Context) ([]byte, error) {
 	var data string
-	response, err := a.Jenkins.Requester.Get(a.Path, &data, nil)
+	response, err := a.Jenkins.Requester.Get(ctx, a.Path, &data, nil)
 
 	if err != nil {
 		return nil, err
@@ -50,11 +51,11 @@ func (a Artifact) GetData() ([]byte, error) {
 }
 
 // Save artifact to a specific path, using your own filename.
-func (a Artifact) Save(path string) (bool, error) {
-	data, err := a.GetData()
+func (a Artifact) Save(ctx context.Context, path string) (bool, error) {
+	data, err := a.GetData(ctx)
 
 	if err != nil {
-		return false, errors.New("No Data received, not saving file.")
+		return false, errors.New("no Data received, not saving file")
 	}
 
 	if _, err = os.Stat(path); err == nil {
@@ -62,7 +63,7 @@ func (a Artifact) Save(path string) (bool, error) {
 	}
 
 	err = ioutil.WriteFile(path, data, 0644)
-	a.validateDownload(path)
+	a.validateDownload(ctx, path)
 
 	if err != nil {
 		return false, err
@@ -71,12 +72,12 @@ func (a Artifact) Save(path string) (bool, error) {
 }
 
 // Save Artifact to directory using Artifact filename.
-func (a Artifact) SaveToDir(dir string) (bool, error) {
+func (a Artifact) SaveToDir(ctx context.Context, dir string) (bool, error) {
 	if _, err := os.Stat(dir); err != nil {
 		Error.Printf("can't save artifact: directory %s does not exist", dir)
 		return false, fmt.Errorf("can't save artifact: directory %s does not exist", dir)
 	}
-	saved, err := a.Save(path.Join(dir, a.FileName))
+	saved, err := a.Save(ctx, path.Join(dir, a.FileName))
 	if err != nil {
 		return saved, nil
 	}
@@ -84,12 +85,12 @@ func (a Artifact) SaveToDir(dir string) (bool, error) {
 }
 
 // Compare Remote and local MD5
-func (a Artifact) validateDownload(path string) (bool, error) {
+func (a Artifact) validateDownload(ctx context.Context, path string) (bool, error) {
 	localHash := a.getMD5local(path)
 
 	fp := FingerPrint{Jenkins: a.Jenkins, Base: "/fingerprint/", Id: localHash, Raw: new(FingerPrintResponse)}
 
-	valid, err := fp.ValidateForBuild(a.FileName, a.Build)
+	valid, err := fp.ValidateForBuild(ctx, a.FileName, a.Build)
 
 	if err != nil {
 		return false, err

--- a/build.go
+++ b/build.go
@@ -16,6 +16,7 @@ package gojenkins
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"net/url"
 	"regexp"
@@ -225,9 +226,9 @@ func (b *Build) GetCulprits() []Culprit {
 	return b.Raw.Culprits
 }
 
-func (b *Build) Stop() (bool, error) {
-	if b.IsRunning() {
-		response, err := b.Jenkins.Requester.Post(b.Base+"/stop", nil, nil, nil)
+func (b *Build) Stop(ctx context.Context) (bool, error) {
+	if b.IsRunning(ctx) {
+		response, err := b.Jenkins.Requester.Post(ctx, b.Base+"/stop", nil, nil, nil)
 		if err != nil {
 			return false, err
 		}
@@ -236,14 +237,14 @@ func (b *Build) Stop() (bool, error) {
 	return true, nil
 }
 
-func (b *Build) GetConsoleOutput() string {
+func (b *Build) GetConsoleOutput(ctx context.Context) string {
 	url := b.Base + "/consoleText"
 	var content string
-	b.Jenkins.Requester.GetXML(url, &content, nil)
+	b.Jenkins.Requester.GetXML(ctx, url, &content, nil)
 	return content
 }
 
-func (b *Build) GetConsoleOutputFromIndex(startID int64) (consoleResponse, error) {
+func (b *Build) GetConsoleOutputFromIndex(ctx context.Context, startID int64) (consoleResponse, error) {
 	strstart := strconv.FormatInt(startID, 10)
 	url := b.Base + "/logText/progressiveText"
 
@@ -251,7 +252,7 @@ func (b *Build) GetConsoleOutputFromIndex(startID int64) (consoleResponse, error
 
 	querymap := make(map[string]string)
 	querymap["start"] = strstart
-	rsp, err := b.Jenkins.Requester.Get(url, &console.Content, querymap)
+	rsp, err := b.Jenkins.Requester.Get(ctx, url, &console.Content, querymap)
 	if err != nil {
 		return console, err
 	}
@@ -266,8 +267,8 @@ func (b *Build) GetConsoleOutputFromIndex(startID int64) (consoleResponse, error
 	return console, err
 }
 
-func (b *Build) GetCauses() ([]map[string]interface{}, error) {
-	_, err := b.Poll()
+func (b *Build) GetCauses(ctx context.Context) ([]map[string]interface{}, error) {
+	_, err := b.Poll(ctx, 3)
 	if err != nil {
 		return nil, err
 	}
@@ -288,35 +289,35 @@ func (b *Build) GetParameters() []parameter {
 	return nil
 }
 
-func (b *Build) GetInjectedEnvVars() (map[string]string, error) {
+func (b *Build) GetInjectedEnvVars(ctx context.Context) (map[string]string, error) {
 	var envVars struct {
 		EnvMap map[string]string `json:"envMap"`
 	}
 	endpoint := b.Base + "/injectedEnvVars"
-	_, err := b.Jenkins.Requester.GetJSON(endpoint, &envVars, nil)
+	_, err := b.Jenkins.Requester.GetJSON(ctx, endpoint, &envVars, nil)
 	if err != nil {
 		return envVars.EnvMap, err
 	}
 	return envVars.EnvMap, nil
 }
 
-func (b *Build) GetDownstreamBuilds() ([]*Build, error) {
+func (b *Build) GetDownstreamBuilds(ctx context.Context) ([]*Build, error) {
 	result := make([]*Build, 0)
-	downstreamJobs, err := b.Job.GetDownstreamJobs()
+	downstreamJobs, err := b.Job.GetDownstreamJobs(ctx)
 	if err != nil {
 		return nil, err
 	}
 	for _, job := range downstreamJobs {
-		allBuildIDs, err := job.GetAllBuildIds()
+		allBuildIDs, err := job.GetAllBuildIds(ctx)
 		if err != nil {
 			return nil, err
 		}
 		for _, buildID := range allBuildIDs {
-			build, err := job.GetBuild(buildID.Number)
+			build, err := job.GetBuild(ctx, buildID.Number)
 			if err != nil {
 				return nil, err
 			}
-			upstreamBuild, err := build.GetUpstreamBuild()
+			upstreamBuild, err := build.GetUpstreamBuild(ctx)
 			// older build may no longer exist, so simply ignore these
 			// cannot compare only id, it can be from different job
 			if err == nil && b.GetUrl() == upstreamBuild.GetUrl() {
@@ -328,10 +329,10 @@ func (b *Build) GetDownstreamBuilds() ([]*Build, error) {
 	return result, nil
 }
 
-func (b *Build) GetDownstreamJobNames() []string {
+func (b *Build) GetDownstreamJobNames(ctx context.Context) []string {
 	result := make([]string, 0)
 	downstreamJobs := b.Job.GetDownstreamJobsMetadata()
-	fingerprints := b.GetAllFingerPrints()
+	fingerprints := b.GetAllFingerPrints(ctx)
 	for _, fingerprint := range fingerprints {
 		for _, usage := range fingerprint.Raw.Usage {
 			for _, job := range downstreamJobs {
@@ -344,8 +345,8 @@ func (b *Build) GetDownstreamJobNames() []string {
 	return result
 }
 
-func (b *Build) GetAllFingerPrints() []*FingerPrint {
-	b.Poll(3)
+func (b *Build) GetAllFingerPrints(ctx context.Context) []*FingerPrint {
+	b.Poll(ctx)
 	result := make([]*FingerPrint, len(b.Raw.FingerPrint))
 	for i, f := range b.Raw.FingerPrint {
 		result[i] = &FingerPrint{Jenkins: b.Jenkins, Base: "/fingerprint/", Id: f.Hash, Raw: &f}
@@ -353,22 +354,22 @@ func (b *Build) GetAllFingerPrints() []*FingerPrint {
 	return result
 }
 
-func (b *Build) GetUpstreamJob() (*Job, error) {
-	causes, err := b.GetCauses()
+func (b *Build) GetUpstreamJob(ctx context.Context) (*Job, error) {
+	causes, err := b.GetCauses(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, cause := range causes {
 		if job, ok := cause["upstreamProject"]; ok {
-			return b.Jenkins.GetJob(job.(string))
+			return b.Jenkins.GetJob(ctx, job.(string))
 		}
 	}
 	return nil, errors.New("Unable to get Upstream Job")
 }
 
-func (b *Build) GetUpstreamBuildNumber() (int64, error) {
-	causes, err := b.GetCauses()
+func (b *Build) GetUpstreamBuildNumber(ctx context.Context) (int64, error) {
+	causes, err := b.GetCauses(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -385,22 +386,22 @@ func (b *Build) GetUpstreamBuildNumber() (int64, error) {
 	return 0, nil
 }
 
-func (b *Build) GetUpstreamBuild() (*Build, error) {
-	job, err := b.GetUpstreamJob()
+func (b *Build) GetUpstreamBuild(ctx context.Context) (*Build, error) {
+	job, err := b.GetUpstreamJob(ctx)
 	if err != nil {
 		return nil, err
 	}
 	if job != nil {
-		buildNumber, err := b.GetUpstreamBuildNumber()
+		buildNumber, err := b.GetUpstreamBuildNumber(ctx)
 		if err == nil && buildNumber != 0 {
-			return job.GetBuild(buildNumber)
+			return job.GetBuild(ctx, buildNumber)
 		}
 	}
 	return nil, errors.New("Build not found")
 }
 
-func (b *Build) GetMatrixRuns() ([]*Build, error) {
-	_, err := b.Poll(0)
+func (b *Build) GetMatrixRuns(ctx context.Context) ([]*Build, error) {
+	_, err := b.Poll(ctx, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -410,17 +411,17 @@ func (b *Build) GetMatrixRuns() ([]*Build, error) {
 
 	for i, run := range runs {
 		result[i] = &Build{Jenkins: b.Jenkins, Job: b.Job, Raw: new(BuildResponse), Depth: 1, Base: "/" + r.FindString(run.URL)}
-		result[i].Poll()
+		result[i].Poll(ctx)
 	}
 	return result, nil
 }
 
-func (b *Build) GetResultSet() (*TestResult, error) {
+func (b *Build) GetResultSet(ctx context.Context) (*TestResult, error) {
 
 	url := b.Base + "/testReport"
 	var report TestResult
 
-	_, err := b.Jenkins.Requester.GetJSON(url, &report, nil)
+	_, err := b.Jenkins.Requester.GetJSON(ctx, url, &report, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -470,28 +471,28 @@ func (b *Build) GetRevisionBranch() string {
 	return ""
 }
 
-func (b *Build) IsGood() bool {
-	return (!b.IsRunning() && b.Raw.Result == STATUS_SUCCESS)
+func (b *Build) IsGood(ctx context.Context) bool {
+	return (!b.IsRunning(ctx) && b.Raw.Result == STATUS_SUCCESS)
 }
 
-func (b *Build) IsRunning() bool {
-	_, err := b.Poll()
+func (b *Build) IsRunning(ctx context.Context) bool {
+	_, err := b.Poll(ctx)
 	if err != nil {
 		return false
 	}
 	return b.Raw.Building
 }
 
-func (b *Build) SetDescription(description string) error {
+func (b *Build) SetDescription(ctx context.Context, description string) error {
 	data := url.Values{}
 	data.Set("description", description)
-	_, err := b.Jenkins.Requester.Post(b.Base+"/submitDescription", bytes.NewBufferString(data.Encode()), nil, nil)
+	_, err := b.Jenkins.Requester.Post(ctx, b.Base+"/submitDescription", bytes.NewBufferString(data.Encode()), nil, nil)
 	return err
 }
 
 // Poll for current data. Optional parameter - depth.
 // More about depth here: https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API
-func (b *Build) Poll(options ...interface{}) (int, error) {
+func (b *Build) Poll(ctx context.Context, options ...interface{}) (int, error) {
 	depth := "-1"
 
 	for _, o := range options {
@@ -511,7 +512,7 @@ func (b *Build) Poll(options ...interface{}) (int, error) {
 	qr := map[string]string{
 		"depth": depth,
 	}
-	response, err := b.Jenkins.Requester.GetJSON(b.Base, b.Raw, qr)
+	response, err := b.Jenkins.Requester.GetJSON(ctx, b.Base, b.Raw, qr)
 	if err != nil {
 		return 0, err
 	}

--- a/build.go
+++ b/build.go
@@ -268,7 +268,7 @@ func (b *Build) GetConsoleOutputFromIndex(ctx context.Context, startID int64) (c
 }
 
 func (b *Build) GetCauses(ctx context.Context) ([]map[string]interface{}, error) {
-	_, err := b.Poll(ctx, 3)
+	_, err := b.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -1,9 +1,11 @@
 package gojenkins
 
 import (
-	"github.com/stretchr/testify/assert"
+	"context"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -24,11 +26,12 @@ func TestCreateUsernameCredentials(t *testing.T) {
 		Password: "pass",
 	}
 
-	err := cm.Add(domain, cred)
+	ctx := context.Background()
+	err := cm.Add(ctx, domain, cred)
 	assert.Nil(t, err, "Could not create credential")
 
 	getCred := UsernameCredentials{}
-	err = cm.GetSingle(domain, cred.ID, &getCred)
+	err = cm.GetSingle(ctx, domain, cred.ID, &getCred)
 	assert.Nil(t, err, "Could not get credential")
 
 	assert.Equal(t, cred.Scope, getCred.Scope, "Scope is not equal")
@@ -46,11 +49,12 @@ func TestCreateDockerCredentials(t *testing.T) {
 		ClientKey:         "client key",
 	}
 
-	err := cm.Add(domain, cred)
+	ctx := context.Background()
+	err := cm.Add(ctx, domain, cred)
 	assert.Nil(t, err, "Could not create credential")
 
 	getCred := DockerServerCredentials{}
-	err = cm.GetSingle(domain, cred.ID, &getCred)
+	err = cm.GetSingle(ctx, domain, cred.ID, &getCred)
 	assert.Nil(t, err, "Could not get credential")
 
 	assert.Equal(t, cred.Scope, getCred.Scope, "Scope is not equal")
@@ -73,15 +77,16 @@ func TestCreateSSHCredentialsFullFlow(t *testing.T) {
 		},
 	}
 
-	err := cm.Add(domain, sshCred)
+	ctx := context.Background()
+	err := cm.Add(ctx, domain, sshCred)
 	assert.Nil(t, err, "Could not create credential")
 
 	sshCred.Username = "new_username"
-	err = cm.Update(domain, sshCred.ID, sshCred)
+	err = cm.Update(ctx, domain, sshCred.ID, sshCred)
 	assert.Nil(t, err, "Could not update credential")
 
 	getSSH := SSHCredentials{}
-	err = cm.GetSingle(domain, sshCred.ID, &getSSH)
+	err = cm.GetSingle(ctx, domain, sshCred.ID, &getSSH)
 	assert.Nil(t, err, "Could not get ssh credential")
 
 	assert.Equal(t, sshCred.Scope, getSSH.Scope, "Scope is not equal")
@@ -89,15 +94,16 @@ func TestCreateSSHCredentialsFullFlow(t *testing.T) {
 	assert.Equal(t, sshCred.Username, getSSH.Username, "Username is not equal")
 	assert.Equal(t, sshCred.Scope, getSSH.Scope, "Scope is not equal")
 
-	err = cm.Delete(domain, getSSH.ID)
+	err = cm.Delete(ctx, domain, getSSH.ID)
 	assert.Nil(t, err, "Could not delete credentials")
 
 }
 
 func TestMain(m *testing.M) {
 	//setup
+	ctx := context.Background()
 	jenkins := CreateJenkins(nil, "http://localhost:8080", "admin", "admin")
-	jenkins.Init()
+	jenkins.Init(ctx)
 
 	cm = CredentialsManager{J: jenkins}
 

--- a/fingerprint.go
+++ b/fingerprint.go
@@ -15,6 +15,7 @@
 package gojenkins
 
 import (
+	"context"
 	"errors"
 	"fmt"
 )
@@ -45,8 +46,8 @@ type FingerPrintResponse struct {
 	} `json:"usage"`
 }
 
-func (f FingerPrint) Valid() (bool, error) {
-	status, err := f.Poll()
+func (f FingerPrint) Valid(ctx context.Context) (bool, error) {
+	status, err := f.Poll(ctx)
 
 	if err != nil {
 		return false, err
@@ -58,8 +59,8 @@ func (f FingerPrint) Valid() (bool, error) {
 	return true, nil
 }
 
-func (f FingerPrint) ValidateForBuild(filename string, build *Build) (bool, error) {
-	valid, err := f.Valid()
+func (f FingerPrint) ValidateForBuild(ctx context.Context, filename string, build *Build) (bool, error) {
+	valid, err := f.Valid(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -78,16 +79,16 @@ func (f FingerPrint) ValidateForBuild(filename string, build *Build) (bool, erro
 	return false, nil
 }
 
-func (f FingerPrint) GetInfo() (*FingerPrintResponse, error) {
-	_, err := f.Poll()
+func (f FingerPrint) GetInfo(ctx context.Context) (*FingerPrintResponse, error) {
+	_, err := f.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return f.Raw, nil
 }
 
-func (f FingerPrint) Poll() (int, error) {
-	response, err := f.Jenkins.Requester.GetJSON(f.Base+f.Id, f.Raw, nil)
+func (f FingerPrint) Poll(ctx context.Context) (int, error) {
+	response, err := f.Jenkins.Requester.GetJSON(ctx, f.Base+f.Id, f.Raw, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/folder.go
+++ b/folder.go
@@ -15,6 +15,7 @@
 package gojenkins
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"strings"
@@ -45,7 +46,7 @@ func (f *Folder) GetName() string {
 	return f.Raw.Name
 }
 
-func (f *Folder) Create(name string) (*Folder, error) {
+func (f *Folder) Create(ctx context.Context, name string) (*Folder, error) {
 	mode := "com.cloudbees.hudson.plugins.folder.Folder"
 	data := map[string]string{
 		"name":   name,
@@ -56,19 +57,19 @@ func (f *Folder) Create(name string) (*Folder, error) {
 			"mode": mode,
 		}),
 	}
-	r, err := f.Jenkins.Requester.Post(f.parentBase()+"/createItem", nil, f.Raw, data)
+	r, err := f.Jenkins.Requester.Post(ctx, f.parentBase()+"/createItem", nil, f.Raw, data)
 	if err != nil {
 		return nil, err
 	}
 	if r.StatusCode == 200 {
-		f.Poll()
+		f.Poll(ctx)
 		return f, nil
 	}
 	return nil, errors.New(strconv.Itoa(r.StatusCode))
 }
 
-func (f *Folder) Poll() (int, error) {
-	response, err := f.Jenkins.Requester.GetJSON(f.Base, f.Raw, nil)
+func (f *Folder) Poll(ctx context.Context) (int, error) {
+	response, err := f.Jenkins.Requester.GetJSON(ctx, f.Base, f.Raw, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa h1:F+8P+gmewFQYRk6JoLQLwjBCTu3mcIURZfNkVweuRKA=
+golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/jenkins.go
+++ b/jenkins.go
@@ -16,6 +16,7 @@
 package gojenkins
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -48,12 +49,12 @@ var (
 // Init Method. Should be called after creating a Jenkins Instance.
 // e.g jenkins,err := CreateJenkins("url").Init()
 // HTTP Client is set here, Connection to jenkins is tested here.
-func (j *Jenkins) Init() (*Jenkins, error) {
+func (j *Jenkins) Init(ctx context.Context) (*Jenkins, error) {
 	j.initLoggers()
 
 	// Check Connection
 	j.Raw = new(ExecutorResponse)
-	rsp, err := j.Requester.GetJSON("/", j.Raw, nil)
+	rsp, err := j.Requester.GetJSON(ctx, "/", j.Raw, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -81,8 +82,8 @@ func (j *Jenkins) initLoggers() {
 }
 
 // Get Basic Information About Jenkins
-func (j *Jenkins) Info() (*ExecutorResponse, error) {
-	rsp, err := j.Requester.GetJSON("/", j.Raw, nil)
+func (j *Jenkins) Info(ctx context.Context) (*ExecutorResponse, error) {
+	rsp, err := j.Requester.GetJSON(ctx, "/", j.Raw, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +95,8 @@ func (j *Jenkins) Info() (*ExecutorResponse, error) {
 }
 
 // SafeRestart jenkins, restart will be done when there are no jobs running
-func (j *Jenkins) SafeRestart() error {
-	_, err := j.Requester.Post("/safeRestart", strings.NewReader(""), struct{}{}, map[string]string{})
+func (j *Jenkins) SafeRestart(ctx context.Context) error {
+	_, err := j.Requester.Post(ctx, "/safeRestart", strings.NewReader(""), struct{}{}, map[string]string{})
 	return err
 }
 
@@ -104,7 +105,7 @@ func (j *Jenkins) SafeRestart() error {
 // Example : jenkins.CreateNode("nodeName", 1, "Description", "/var/lib/jenkins", "jdk8 docker", map[string]string{"method": "JNLPLauncher"})
 // By Default JNLPLauncher is created
 // Multiple labels should be separated by blanks
-func (j *Jenkins) CreateNode(name string, numExecutors int, description string, remoteFS string, label string, options ...interface{}) (*Node, error) {
+func (j *Jenkins) CreateNode(ctx context.Context, name string, numExecutors int, description string, remoteFS string, label string, options ...interface{}) (*Node, error) {
 	params := map[string]string{"method": "JNLPLauncher"}
 
 	if len(options) > 0 {
@@ -162,14 +163,14 @@ func (j *Jenkins) CreateNode(name string, numExecutors int, description string, 
 		}),
 	}
 
-	resp, err := j.Requester.Post("/computer/doCreateItem", nil, nil, qr)
+	resp, err := j.Requester.Post(ctx, "/computer/doCreateItem", nil, nil, qr)
 
 	if err != nil {
 		return nil, err
 	}
 
 	if resp.StatusCode < 400 {
-		_, err := node.Poll()
+		_, err := node.Poll(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -179,17 +180,17 @@ func (j *Jenkins) CreateNode(name string, numExecutors int, description string, 
 }
 
 // Delete a Jenkins slave node
-func (j *Jenkins) DeleteNode(name string) (bool, error) {
+func (j *Jenkins) DeleteNode(ctx context.Context, name string) (bool, error) {
 	node := Node{Jenkins: j, Raw: new(NodeResponse), Base: "/computer/" + name}
-	return node.Delete()
+	return node.Delete(ctx)
 }
 
 // Create a new folder
 // This folder can be nested in other parent folders
 // Example: jenkins.CreateFolder("newFolder", "grandparentFolder", "parentFolder")
-func (j *Jenkins) CreateFolder(name string, parents ...string) (*Folder, error) {
+func (j *Jenkins) CreateFolder(ctx context.Context, name string, parents ...string) (*Folder, error) {
 	folderObj := &Folder{Jenkins: j, Raw: new(FolderResponse), Base: "/job/" + strings.Join(append(parents, name), "/job/")}
-	folder, err := folderObj.Create(name)
+	folder, err := folderObj.Create(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -198,12 +199,12 @@ func (j *Jenkins) CreateFolder(name string, parents ...string) (*Folder, error) 
 
 // Create a new job in the folder
 // Example: jenkins.CreateJobInFolder("<config></config>", "newJobName", "myFolder", "parentFolder")
-func (j *Jenkins) CreateJobInFolder(config string, jobName string, parentIDs ...string) (*Job, error) {
+func (j *Jenkins) CreateJobInFolder(ctx context.Context, config string, jobName string, parentIDs ...string) (*Job, error) {
 	jobObj := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + strings.Join(append(parentIDs, jobName), "/job/")}
 	qr := map[string]string{
 		"name": jobName,
 	}
-	job, err := jobObj.Create(config, qr)
+	job, err := jobObj.Create(ctx, config, qr)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (j *Jenkins) CreateJobInFolder(config string, jobName string, parentIDs ...
 // Method takes XML string as first parameter, and if the name is not specified in the config file
 // takes name as string as second parameter
 // e.g jenkins.CreateJob("<config></config>","newJobName")
-func (j *Jenkins) CreateJob(config string, options ...interface{}) (*Job, error) {
+func (j *Jenkins) CreateJob(ctx context.Context, config string, options ...interface{}) (*Job, error) {
 	qr := make(map[string]string)
 	if len(options) > 0 {
 		qr["name"] = options[0].(string)
@@ -222,7 +223,7 @@ func (j *Jenkins) CreateJob(config string, options ...interface{}) (*Job, error)
 		return nil, errors.New("Error Creating Job, job name is missing")
 	}
 	jobObj := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + qr["name"]}
-	job, err := jobObj.Create(config, qr)
+	job, err := jobObj.Create(ctx, config, qr)
 	if err != nil {
 		return nil, err
 	}
@@ -231,51 +232,51 @@ func (j *Jenkins) CreateJob(config string, options ...interface{}) (*Job, error)
 
 // Update a job.
 // If a job is exist, update its config
-func (j *Jenkins) UpdateJob(job string, config string) *Job {
+func (j *Jenkins) UpdateJob(ctx context.Context, job string, config string) *Job {
 	jobObj := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + job}
-	jobObj.UpdateConfig(config)
+	jobObj.UpdateConfig(ctx, config)
 	return &jobObj
 }
 
 // Rename a job.
 // First parameter job old name, Second parameter job new name.
-func (j *Jenkins) RenameJob(job string, name string) *Job {
+func (j *Jenkins) RenameJob(ctx context.Context, job string, name string) *Job {
 	jobObj := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + job}
-	jobObj.Rename(name)
+	jobObj.Rename(ctx, name)
 	return &jobObj
 }
 
 // Create a copy of a job.
 // First parameter Name of the job to copy from, Second parameter new job name.
-func (j *Jenkins) CopyJob(copyFrom string, newName string) (*Job, error) {
+func (j *Jenkins) CopyJob(ctx context.Context, copyFrom string, newName string) (*Job, error) {
 	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + copyFrom}
-	_, err := job.Poll()
+	_, err := job.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return job.Copy(newName)
+	return job.Copy(ctx, newName)
 }
 
 // Delete a job.
-func (j *Jenkins) DeleteJob(name string) (bool, error) {
+func (j *Jenkins) DeleteJob(ctx context.Context, name string) (bool, error) {
 	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + name}
-	return job.Delete()
+	return job.Delete(ctx)
 }
 
 // Invoke a job.
 // First parameter job name, second parameter is optional Build parameters.
-func (j *Jenkins) BuildJob(name string, options ...interface{}) (int64, error) {
+func (j *Jenkins) BuildJob(ctx context.Context, name string, options ...interface{}) (int64, error) {
 	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + name}
 	var params map[string]string
 	if len(options) > 0 {
 		params, _ = options[0].(map[string]string)
 	}
-	return job.InvokeSimple(params)
+	return job.InvokeSimple(ctx, params)
 }
 
-func (j *Jenkins) GetNode(name string) (*Node, error) {
+func (j *Jenkins) GetNode(ctx context.Context, name string) (*Node, error) {
 	node := Node{Jenkins: j, Raw: new(NodeResponse), Base: "/computer/" + name}
-	status, err := node.Poll()
+	status, err := node.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -285,9 +286,9 @@ func (j *Jenkins) GetNode(name string) (*Node, error) {
 	return nil, errors.New("No node found")
 }
 
-func (j *Jenkins) GetLabel(name string) (*Label, error) {
+func (j *Jenkins) GetLabel(ctx context.Context, name string) (*Label, error) {
 	label := Label{Jenkins: j, Raw: new(LabelResponse), Base: "/label/" + name}
-	status, err := label.Poll()
+	status, err := label.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -297,12 +298,12 @@ func (j *Jenkins) GetLabel(name string) (*Label, error) {
 	return nil, errors.New("No label found")
 }
 
-func (j *Jenkins) GetBuild(jobName string, number int64) (*Build, error) {
-	job, err := j.GetJob(jobName)
+func (j *Jenkins) GetBuild(ctx context.Context, jobName string, number int64) (*Build, error) {
+	job, err := j.GetJob(ctx, jobName)
 	if err != nil {
 		return nil, err
 	}
-	build, err := job.GetBuild(number)
+	build, err := job.GetBuild(ctx, number)
 
 	if err != nil {
 		return nil, err
@@ -310,9 +311,9 @@ func (j *Jenkins) GetBuild(jobName string, number int64) (*Build, error) {
 	return build, nil
 }
 
-func (j *Jenkins) GetJob(id string, parentIDs ...string) (*Job, error) {
+func (j *Jenkins) GetJob(ctx context.Context, id string, parentIDs ...string) (*Job, error) {
 	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + strings.Join(append(parentIDs, id), "/job/")}
-	status, err := job.Poll()
+	status, err := job.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -322,9 +323,9 @@ func (j *Jenkins) GetJob(id string, parentIDs ...string) (*Job, error) {
 	return nil, errors.New(strconv.Itoa(status))
 }
 
-func (j *Jenkins) GetSubJob(parentId string, childId string) (*Job, error) {
+func (j *Jenkins) GetSubJob(ctx context.Context, parentId string, childId string) (*Job, error) {
 	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + parentId + "/job/" + childId}
-	status, err := job.Poll()
+	status, err := job.Poll(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("trouble polling job: %v", err)
 	}
@@ -334,9 +335,9 @@ func (j *Jenkins) GetSubJob(parentId string, childId string) (*Job, error) {
 	return nil, errors.New(strconv.Itoa(status))
 }
 
-func (j *Jenkins) GetFolder(id string, parents ...string) (*Folder, error) {
+func (j *Jenkins) GetFolder(ctx context.Context, id string, parents ...string) (*Folder, error) {
 	folder := Folder{Jenkins: j, Raw: new(FolderResponse), Base: "/job/" + strings.Join(append(parents, id), "/job/")}
-	status, err := folder.Poll()
+	status, err := folder.Poll(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("trouble polling folder: %v", err)
 	}
@@ -346,14 +347,14 @@ func (j *Jenkins) GetFolder(id string, parents ...string) (*Folder, error) {
 	return nil, errors.New(strconv.Itoa(status))
 }
 
-func (j *Jenkins) GetAllNodes() ([]*Node, error) {
+func (j *Jenkins) GetAllNodes(ctx context.Context) ([]*Node, error) {
 	computers := new(Computers)
 
 	qr := map[string]string{
 		"depth": "1",
 	}
 
-	_, err := j.Requester.GetJSON("/computer", computers, qr)
+	_, err := j.Requester.GetJSON(ctx, "/computer", computers, qr)
 	if err != nil {
 		return nil, err
 	}
@@ -370,19 +371,19 @@ func (j *Jenkins) GetAllNodes() ([]*Node, error) {
 // There are only build IDs here,
 // To get all the other info of the build use jenkins.GetBuild(job,buildNumber)
 // or job.GetBuild(buildNumber)
-func (j *Jenkins) GetAllBuildIds(job string) ([]JobBuild, error) {
-	jobObj, err := j.GetJob(job)
+func (j *Jenkins) GetAllBuildIds(ctx context.Context, job string) ([]JobBuild, error) {
+	jobObj, err := j.GetJob(ctx, job)
 	if err != nil {
 		return nil, err
 	}
-	return jobObj.GetAllBuildIds()
+	return jobObj.GetAllBuildIds(ctx)
 }
 
 // Get Only Array of Job Names, Color, URL
 // Does not query each single Job.
-func (j *Jenkins) GetAllJobNames() ([]InnerJob, error) {
+func (j *Jenkins) GetAllJobNames(ctx context.Context) ([]InnerJob, error) {
 	exec := Executor{Raw: new(ExecutorResponse), Jenkins: j}
-	_, err := j.Requester.GetJSON("/", exec.Raw, nil)
+	_, err := j.Requester.GetJSON(ctx, "/", exec.Raw, nil)
 
 	if err != nil {
 		return nil, err
@@ -393,9 +394,9 @@ func (j *Jenkins) GetAllJobNames() ([]InnerJob, error) {
 
 // Get All Possible Job Objects.
 // Each job will be queried.
-func (j *Jenkins) GetAllJobs() ([]*Job, error) {
+func (j *Jenkins) GetAllJobs(ctx context.Context) ([]*Job, error) {
 	exec := Executor{Raw: new(ExecutorResponse), Jenkins: j}
-	_, err := j.Requester.GetJSON("/", exec.Raw, nil)
+	_, err := j.Requester.GetJSON(ctx, "/", exec.Raw, nil)
 
 	if err != nil {
 		return nil, err
@@ -403,7 +404,7 @@ func (j *Jenkins) GetAllJobs() ([]*Job, error) {
 
 	jobs := make([]*Job, len(exec.Raw.Jobs))
 	for i, job := range exec.Raw.Jobs {
-		ji, err := j.GetJob(job.Name)
+		ji, err := j.GetJob(ctx, job.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -413,9 +414,9 @@ func (j *Jenkins) GetAllJobs() ([]*Job, error) {
 }
 
 // Returns a Queue
-func (j *Jenkins) GetQueue() (*Queue, error) {
+func (j *Jenkins) GetQueue(ctx context.Context) (*Queue, error) {
 	q := &Queue{Jenkins: j, Raw: new(queueResponse), Base: j.GetQueueUrl()}
-	_, err := q.Poll()
+	_, err := q.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -427,9 +428,9 @@ func (j *Jenkins) GetQueueUrl() string {
 }
 
 // GetQueueItem returns a single queue Task
-func (j *Jenkins) GetQueueItem(id int64) (*Task, error) {
+func (j *Jenkins) GetQueueItem(ctx context.Context, id int64) (*Task, error) {
 	t := &Task{Raw: new(taskResponse), Jenkins: j, Base: j.getQueueItemURL(id)}
-	_, err := t.Poll()
+	_, err := t.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -441,16 +442,16 @@ func (j *Jenkins) getQueueItemURL(id int64) string {
 }
 
 // Get Artifact data by Hash
-func (j *Jenkins) GetArtifactData(id string) (*FingerPrintResponse, error) {
+func (j *Jenkins) GetArtifactData(ctx context.Context, id string) (*FingerPrintResponse, error) {
 	fp := FingerPrint{Jenkins: j, Base: "/fingerprint/", Id: id, Raw: new(FingerPrintResponse)}
-	return fp.GetInfo()
+	return fp.GetInfo(ctx)
 }
 
 // Returns the list of all plugins installed on the Jenkins server.
 // You can supply depth parameter, to limit how much data is returned.
-func (j *Jenkins) GetPlugins(depth int) (*Plugins, error) {
+func (j *Jenkins) GetPlugins(ctx context.Context, depth int) (*Plugins, error) {
 	p := Plugins{Jenkins: j, Raw: new(PluginResponse), Base: "/pluginManager", Depth: depth}
-	_, err := p.Poll()
+	_, err := p.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -458,9 +459,9 @@ func (j *Jenkins) GetPlugins(depth int) (*Plugins, error) {
 }
 
 // UninstallPlugin plugin otherwise returns error
-func (j *Jenkins) UninstallPlugin(name string) error {
+func (j *Jenkins) UninstallPlugin(ctx context.Context, name string) error {
 	url := fmt.Sprintf("/pluginManager/plugin/%s/doUninstall", name)
-	resp, err := j.Requester.Post(url, strings.NewReader(""), struct{}{}, map[string]string{})
+	resp, err := j.Requester.Post(ctx, url, strings.NewReader(""), struct{}{}, map[string]string{})
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("Invalid status code returned: %d", resp.StatusCode)
 	}
@@ -469,8 +470,8 @@ func (j *Jenkins) UninstallPlugin(name string) error {
 
 // Check if the plugin is installed on the server.
 // Depth level 1 is used. If you need to go deeper, you can use GetPlugins, and iterate through them.
-func (j *Jenkins) HasPlugin(name string) (*Plugin, error) {
-	p, err := j.GetPlugins(1)
+func (j *Jenkins) HasPlugin(ctx context.Context, name string) (*Plugin, error) {
+	p, err := j.GetPlugins(ctx, 1)
 
 	if err != nil {
 		return nil, err
@@ -479,9 +480,9 @@ func (j *Jenkins) HasPlugin(name string) (*Plugin, error) {
 }
 
 //InstallPlugin with given version and name
-func (j *Jenkins) InstallPlugin(name string, version string) error {
+func (j *Jenkins) InstallPlugin(ctx context.Context, name string, version string) error {
 	xml := fmt.Sprintf(`<jenkins><install plugin="%s@%s" /></jenkins>`, name, version)
-	resp, err := j.Requester.PostXML("/pluginManager/installNecessaryPlugins", xml, j.Raw, map[string]string{})
+	resp, err := j.Requester.PostXML(ctx, "/pluginManager/installNecessaryPlugins", xml, j.Raw, map[string]string{})
 
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("Invalid status code returned: %d", resp.StatusCode)
@@ -490,9 +491,9 @@ func (j *Jenkins) InstallPlugin(name string, version string) error {
 }
 
 // Verify FingerPrint
-func (j *Jenkins) ValidateFingerPrint(id string) (bool, error) {
+func (j *Jenkins) ValidateFingerPrint(ctx context.Context, id string) (bool, error) {
 	fp := FingerPrint{Jenkins: j, Base: "/fingerprint/", Id: id, Raw: new(FingerPrintResponse)}
-	valid, err := fp.Valid()
+	valid, err := fp.Valid(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -502,24 +503,24 @@ func (j *Jenkins) ValidateFingerPrint(id string) (bool, error) {
 	return false, nil
 }
 
-func (j *Jenkins) GetView(name string) (*View, error) {
+func (j *Jenkins) GetView(ctx context.Context, name string) (*View, error) {
 	url := "/view/" + name
 	view := View{Jenkins: j, Raw: new(ViewResponse), Base: url}
-	_, err := view.Poll()
+	_, err := view.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return &view, nil
 }
 
-func (j *Jenkins) GetAllViews() ([]*View, error) {
-	_, err := j.Poll()
+func (j *Jenkins) GetAllViews(ctx context.Context) ([]*View, error) {
+	_, err := j.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
 	views := make([]*View, len(j.Raw.Views))
 	for i, v := range j.Raw.Views {
-		views[i], _ = j.GetView(v.Name)
+		views[i], _ = j.GetView(ctx, v.Name)
 	}
 	return views, nil
 }
@@ -534,7 +535,7 @@ func (j *Jenkins) GetAllViews() ([]*View, error) {
 // 		gojenkins.DASHBOARD_VIEW
 // 		gojenkins.PIPELINE_VIEW
 // Example: jenkins.CreateView("newView",gojenkins.LIST_VIEW)
-func (j *Jenkins) CreateView(name string, viewType string) (*View, error) {
+func (j *Jenkins) CreateView(ctx context.Context, name string, viewType string) (*View, error) {
 	view := &View{Jenkins: j, Raw: new(ViewResponse), Base: "/view/" + name}
 	endpoint := "/createView"
 	data := map[string]string{
@@ -546,20 +547,20 @@ func (j *Jenkins) CreateView(name string, viewType string) (*View, error) {
 			"mode": viewType,
 		}),
 	}
-	r, err := j.Requester.Post(endpoint, nil, view.Raw, data)
+	r, err := j.Requester.Post(ctx, endpoint, nil, view.Raw, data)
 
 	if err != nil {
 		return nil, err
 	}
 
 	if r.StatusCode == 200 {
-		return j.GetView(name)
+		return j.GetView(ctx, name)
 	}
 	return nil, errors.New(strconv.Itoa(r.StatusCode))
 }
 
-func (j *Jenkins) Poll() (int, error) {
-	resp, err := j.Requester.GetJSON("/", j.Raw, nil)
+func (j *Jenkins) Poll(ctx context.Context) (int, error) {
+	resp, err := j.Requester.GetJSON(ctx, "/", j.Raw, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -1,6 +1,7 @@
 package gojenkins
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -15,8 +16,9 @@ var (
 )
 
 func TestInit(t *testing.T) {
+	ctx := context.Background()
 	jenkins = CreateJenkins(nil, "http://localhost:8080", "admin", "admin")
-	_, err := jenkins.Init()
+	_, err := jenkins.Init(ctx)
 	assert.Nil(t, err, "Jenkins Initialization should not fail")
 }
 
@@ -25,18 +27,18 @@ func TestCreateJobs(t *testing.T) {
 	job2ID := "job2_test"
 	job_data := getFileAsString("job.xml")
 
-	job1, err := jenkins.CreateJob(job_data, job1ID)
+	ctx := context.Background()
+	job1, err := jenkins.CreateJob(ctx, job_data, job1ID)
 	assert.Nil(t, err)
 	assert.NotNil(t, job1)
 	assert.Equal(t, "Some Job Description", job1.GetDescription())
 	assert.Equal(t, job1ID, job1.GetName())
 
-	job2, _ := jenkins.CreateJob(job_data, job2ID)
+	job2, _ := jenkins.CreateJob(ctx, job_data, job2ID)
 	assert.NotNil(t, job2)
 	assert.Equal(t, "Some Job Description", job2.GetDescription())
 	assert.Equal(t, job2ID, job2.GetName())
 }
-
 
 func TestCreateNodes(t *testing.T) {
 
@@ -48,33 +50,37 @@ func TestCreateNodes(t *testing.T) {
 	jnlp := map[string]string{"method": "JNLPLauncher"}
 	//ssh := map[string]string{"method": "SSHLauncher"}
 
-	node1, _ := jenkins.CreateNode(id1, 1, "Node 1 Description", "/var/lib/jenkins", "", jnlp)
+	ctx := context.Background()
+	node1, _ := jenkins.CreateNode(ctx, id1, 1, "Node 1 Description", "/var/lib/jenkins", "", jnlp)
 	assert.Equal(t, id1, node1.GetName())
 
 	//node2, _ := jenkins.CreateNode(id2, 1, "Node 2 Description", "/var/lib/jenkins", "jdk8 docker", ssh)
 	//assert.Equal(t, id2, node2.GetName())
 
-	node3, _ := jenkins.CreateNode(id3, 1, "Node 3 Description", "/var/lib/jenkins", "jdk7")
+	node3, _ := jenkins.CreateNode(ctx, id3, 1, "Node 3 Description", "/var/lib/jenkins", "jdk7")
 	assert.Equal(t, id3, node3.GetName())
-	node4, _ := jenkins.CreateNode(id4, 1, "Node 4 Description", "/var/lib/jenkins", "jdk7")
+	node4, _ := jenkins.CreateNode(ctx, id4, 1, "Node 4 Description", "/var/lib/jenkins", "jdk7")
 	assert.Equal(t, id4, node4.GetName())
 }
 
 func TestDeleteNodes(t *testing.T) {
 	id := "node4_test"
-	node, _ := jenkins.DeleteNode(id)
+
+	ctx := context.Background()
+	node, _ := jenkins.DeleteNode(ctx, id)
 	assert.NotNil(t, node)
 }
 
 func TestCreateBuilds(t *testing.T) {
-	jobs, _ := jenkins.GetAllJobs()
+	ctx := context.Background()
+	jobs, _ := jenkins.GetAllJobs(ctx)
 	for _, item := range jobs {
-		queueID, _ = item.InvokeSimple(map[string]string{"params1": "param1"})
-		item.Poll()
-		isQueued, _ := item.IsQueued()
+		queueID, _ = item.InvokeSimple(ctx, map[string]string{"params1": "param1"})
+		item.Poll(ctx)
+		isQueued, _ := item.IsQueued(ctx)
 		assert.Equal(t, true, isQueued)
 		time.Sleep(10 * time.Second)
-		builds, _ := item.GetAllBuildIds()
+		builds, _ := item.GetAllBuildIds(ctx)
 
 		assert.True(t, (len(builds) > 0))
 
@@ -82,7 +88,8 @@ func TestCreateBuilds(t *testing.T) {
 }
 
 func TestGetQueueItem(t *testing.T) {
-	task, err := jenkins.GetQueueItem(queueID)
+	ctx := context.Background()
+	task, err := jenkins.GetQueueItem(ctx, queueID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,13 +108,14 @@ func TestParseBuildHistory(t *testing.T) {
 }
 
 func TestCreateViews(t *testing.T) {
-	list_view, err := jenkins.CreateView("test_list_view", LIST_VIEW)
+	ctx := context.Background()
+	list_view, err := jenkins.CreateView(ctx, "test_list_view", LIST_VIEW)
 	assert.Nil(t, err)
 	assert.Equal(t, "test_list_view", list_view.GetName())
 	assert.Equal(t, "", list_view.GetDescription())
 	assert.Equal(t, 0, len(list_view.GetJobs()))
 
-	my_view, err := jenkins.CreateView("test_my_view", MY_VIEW)
+	my_view, err := jenkins.CreateView(ctx, "test_my_view", MY_VIEW)
 	assert.Nil(t, err)
 	assert.Equal(t, "test_my_view", my_view.GetName())
 	assert.Equal(t, "", my_view.GetDescription())
@@ -116,33 +124,37 @@ func TestCreateViews(t *testing.T) {
 }
 
 func TestGetAllJobs(t *testing.T) {
-	jobs, _ := jenkins.GetAllJobs()
+	ctx := context.Background()
+	jobs, _ := jenkins.GetAllJobs(ctx)
 	assert.Equal(t, 2, len(jobs))
 	assert.Equal(t, jobs[0].Raw.Color, "blue")
 }
 
 func TestGetAllNodes(t *testing.T) {
-	nodes, _ := jenkins.GetAllNodes()
+	ctx := context.Background()
+	nodes, _ := jenkins.GetAllNodes(ctx)
 	assert.Equal(t, 3, len(nodes))
 	assert.Equal(t, nodes[0].GetName(), "master")
 }
 
 func TestGetAllBuilds(t *testing.T) {
-	builds, _ := jenkins.GetAllBuildIds("Job1_test")
+	ctx := context.Background()
+	builds, _ := jenkins.GetAllBuildIds(ctx, "Job1_test")
 	for _, b := range builds {
-		build, _ := jenkins.GetBuild("Job1_test", b.Number)
+		build, _ := jenkins.GetBuild(ctx, "Job1_test", b.Number)
 		assert.Equal(t, "SUCCESS", build.GetResult())
 	}
 	assert.Equal(t, 1, len(builds))
 }
 
 func TestGetLabel(t *testing.T) {
-	label, err := jenkins.GetLabel("test_label")
+	ctx := context.Background()
+	label, err := jenkins.GetLabel(ctx, "test_label")
 	assert.Nil(t, err)
 	assert.Equal(t, label.GetName(), "test_label")
 	assert.Equal(t, 0, len(label.GetNodes()))
 
-	label, err = jenkins.GetLabel("jdk7")
+	label, err = jenkins.GetLabel(ctx, "jdk7")
 	assert.Nil(t, err)
 	assert.Equal(t, label.GetName(), "jdk7")
 	assert.Equal(t, 1, len(label.GetNodes()))
@@ -162,82 +174,91 @@ func TestGetLabel(t *testing.T) {
 }
 
 func TestBuildMethods(t *testing.T) {
-	job, _ := jenkins.GetJob("Job1_test")
-	build, _ := job.GetLastBuild()
+	ctx := context.Background()
+	job, _ := jenkins.GetJob(ctx, "Job1_test")
+	build, _ := job.GetLastBuild(ctx)
 	params := build.GetParameters()
 	assert.Equal(t, "params1", params[0].Name)
 }
 
 func TestGetSingleJob(t *testing.T) {
-	job, _ := jenkins.GetJob("Job1_test")
-	isRunning, _ := job.IsRunning()
-	config, err := job.GetConfig()
+	ctx := context.Background()
+	job, _ := jenkins.GetJob(ctx, "Job1_test")
+	isRunning, _ := job.IsRunning(ctx)
+	config, err := job.GetConfig(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, false, isRunning)
 	assert.Contains(t, config, "<project>")
 }
 
 func TestEnableDisableJob(t *testing.T) {
-	job, _ := jenkins.GetJob("Job1_test")
-	result, _ := job.Disable()
+	ctx := context.Background()
+	job, _ := jenkins.GetJob(ctx, "Job1_test")
+	result, _ := job.Disable(ctx)
 	assert.Equal(t, true, result)
-	result, _ = job.Enable()
+	result, _ = job.Enable(ctx)
 	assert.Equal(t, true, result)
 }
 
 func TestCopyDeleteJob(t *testing.T) {
-	job, _ := jenkins.GetJob("Job1_test")
-	jobCopy, _ := job.Copy("Job1_test_copy")
+	ctx := context.Background()
+	job, _ := jenkins.GetJob(ctx, "Job1_test")
+	jobCopy, _ := job.Copy(ctx, "Job1_test_copy")
 	assert.Equal(t, jobCopy.GetName(), "Job1_test_copy")
-	jobDelete, _ := job.Delete()
+	jobDelete, _ := job.Delete(ctx)
 	assert.Equal(t, true, jobDelete)
 }
 
 func TestGetPlugins(t *testing.T) {
-	plugins, _ := jenkins.GetPlugins(3)
+	ctx := context.Background()
+	plugins, _ := jenkins.GetPlugins(ctx, 3)
 	assert.Equal(t, 10, plugins.Count())
 }
 
 func TestGetViews(t *testing.T) {
-	views, _ := jenkins.GetAllViews()
+	ctx := context.Background()
+	views, _ := jenkins.GetAllViews(ctx)
 	assert.Equal(t, len(views), 3)
 	assert.Equal(t, len(views[0].Raw.Jobs), 2)
 }
 
 func TestGetSingleView(t *testing.T) {
-	view, _ := jenkins.GetView("All")
-	view2, _ := jenkins.GetView("test_list_view")
+	ctx := context.Background()
+	view, _ := jenkins.GetView(ctx, "All")
+	view2, _ := jenkins.GetView(ctx, "test_list_view")
 	assert.Equal(t, len(view.Raw.Jobs), 2)
 	assert.Equal(t, len(view2.Raw.Jobs), 0)
 	assert.Equal(t, view2.Raw.Name, "test_list_view")
 }
 
 func TestCreateFolder(t *testing.T) {
+	ctx := context.Background()
 	folder1ID := "folder1_test"
 	folder2ID := "folder2_test"
 
-	folder1, err := jenkins.CreateFolder(folder1ID)
+	folder1, err := jenkins.CreateFolder(ctx, folder1ID)
 	assert.Nil(t, err)
 	assert.NotNil(t, folder1)
 	assert.Equal(t, folder1ID, folder1.GetName())
 
-	folder2, err := jenkins.CreateFolder(folder2ID, folder1ID)
+	folder2, err := jenkins.CreateFolder(ctx, folder2ID, folder1ID)
 	assert.Nil(t, err)
 	assert.NotNil(t, folder2)
 	assert.Equal(t, folder2ID, folder2.GetName())
 }
 
 func TestCreateJobInFolder(t *testing.T) {
+	ctx := context.Background()
 	jobName := "Job_test"
 	job_data := getFileAsString("job.xml")
 
-	job1, err := jenkins.CreateJobInFolder(job_data, jobName, "folder1_test")
+	job1, err := jenkins.CreateJobInFolder(ctx, job_data, jobName, "folder1_test")
 	assert.Nil(t, err)
 	assert.NotNil(t, job1)
 	assert.Equal(t, "Some Job Description", job1.GetDescription())
 	assert.Equal(t, jobName, job1.GetName())
 
-	job2, err := jenkins.CreateJobInFolder(job_data, jobName, "folder1_test", "folder2_test")
+	job2, err := jenkins.CreateJobInFolder(ctx, job_data, jobName, "folder1_test", "folder2_test")
 	assert.Nil(t, err)
 	assert.NotNil(t, job2)
 	assert.Equal(t, "Some Job Description", job2.GetDescription())
@@ -245,32 +266,35 @@ func TestCreateJobInFolder(t *testing.T) {
 }
 
 func TestGetFolder(t *testing.T) {
+	ctx := context.Background()
 	folder1ID := "folder1_test"
 	folder2ID := "folder2_test"
 
-	folder1, err := jenkins.GetFolder(folder1ID)
+	folder1, err := jenkins.GetFolder(ctx, folder1ID)
 	assert.Nil(t, err)
 	assert.NotNil(t, folder1)
 	assert.Equal(t, folder1ID, folder1.GetName())
 
-	folder2, err := jenkins.GetFolder(folder2ID, folder1ID)
+	folder2, err := jenkins.GetFolder(ctx, folder2ID, folder1ID)
 	assert.Nil(t, err)
 	assert.NotNil(t, folder2)
 	assert.Equal(t, folder2ID, folder2.GetName())
 }
 func TestInstallPlugin(t *testing.T) {
+	ctx := context.Background()
 
-	err := jenkins.InstallPlugin("packer", "1.4")
+	err := jenkins.InstallPlugin(ctx, "packer", "1.4")
 
 	assert.Nil(t, err, "Could not install plugin")
 }
 
 func TestConcurrentRequests(t *testing.T) {
+	ctx := context.Background()
 	for i := 0; i <= 16; i++ {
 		go func() {
-			jenkins.GetAllJobs()
-			jenkins.GetAllViews()
-			jenkins.GetAllNodes()
+			jenkins.GetAllJobs(ctx)
+			jenkins.GetAllViews(ctx)
+			jenkins.GetAllNodes(ctx)
 		}()
 	}
 }

--- a/job.go
+++ b/job.go
@@ -16,6 +16,7 @@ package gojenkins
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -119,7 +120,7 @@ func (j *Job) GetDetails() *JobResponse {
 	return j.Raw
 }
 
-func (j *Job) GetBuild(id int64) (*Build, error) {
+func (j *Job) GetBuild(ctx context.Context, id int64) (*Build, error) {
 	// use job embedded URL to properly handle jobs in folders
 	url, err := url.Parse(j.Raw.URL)
 	if err != nil {
@@ -127,7 +128,7 @@ func (j *Job) GetBuild(id int64) (*Build, error) {
 	}
 	jobURL := url.Path
 	build := Build{Jenkins: j.Jenkins, Job: j, Raw: new(BuildResponse), Depth: 1, Base: jobURL + "/" + strconv.FormatInt(id, 10)}
-	status, err := build.Poll()
+	status, err := build.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +138,7 @@ func (j *Job) GetBuild(id int64) (*Build, error) {
 	return nil, errors.New(strconv.Itoa(status))
 }
 
-func (j *Job) getBuildByType(buildType string) (*Build, error) {
+func (j *Job) getBuildByType(ctx context.Context, buildType string) (*Build, error) {
 	allowed := map[string]JobBuild{
 		"lastStableBuild":     j.Raw.LastStableBuild,
 		"lastSuccessfulBuild": j.Raw.LastSuccessfulBuild,
@@ -158,7 +159,7 @@ func (j *Job) getBuildByType(buildType string) (*Build, error) {
 		Job:     j,
 		Raw:     new(BuildResponse),
 		Base:    j.Base + "/" + number}
-	status, err := build.Poll()
+	status, err := build.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -168,36 +169,36 @@ func (j *Job) getBuildByType(buildType string) (*Build, error) {
 	return nil, errors.New(strconv.Itoa(status))
 }
 
-func (j *Job) GetLastSuccessfulBuild() (*Build, error) {
-	return j.getBuildByType("lastSuccessfulBuild")
+func (j *Job) GetLastSuccessfulBuild(ctx context.Context) (*Build, error) {
+	return j.getBuildByType(ctx, "lastSuccessfulBuild")
 }
 
-func (j *Job) GetFirstBuild() (*Build, error) {
-	return j.getBuildByType("firstBuild")
+func (j *Job) GetFirstBuild(ctx context.Context) (*Build, error) {
+	return j.getBuildByType(ctx, "firstBuild")
 }
 
-func (j *Job) GetLastBuild() (*Build, error) {
-	return j.getBuildByType("lastBuild")
+func (j *Job) GetLastBuild(ctx context.Context) (*Build, error) {
+	return j.getBuildByType(ctx, "lastBuild")
 }
 
-func (j *Job) GetLastStableBuild() (*Build, error) {
-	return j.getBuildByType("lastStableBuild")
+func (j *Job) GetLastStableBuild(ctx context.Context) (*Build, error) {
+	return j.getBuildByType(ctx, "lastStableBuild")
 }
 
-func (j *Job) GetLastFailedBuild() (*Build, error) {
-	return j.getBuildByType("lastFailedBuild")
+func (j *Job) GetLastFailedBuild(ctx context.Context) (*Build, error) {
+	return j.getBuildByType(ctx, "lastFailedBuild")
 }
 
-func (j *Job) GetLastCompletedBuild() (*Build, error) {
-	return j.getBuildByType("lastCompletedBuild")
+func (j *Job) GetLastCompletedBuild(ctx context.Context) (*Build, error) {
+	return j.getBuildByType(ctx, "lastCompletedBuild")
 }
 
-func (j *Job) GetBuildsFields(fields []string, custom interface{}) error {
+func (j *Job) GetBuildsFields(ctx context.Context, fields []string, custom interface{}) error {
 	if fields == nil || len(fields) == 0 {
 		return fmt.Errorf("one or more field value needs to be specified")
 	}
 	// limit overhead using builds instead of allBuilds, which returns the last 100 build
-	_, err := j.Jenkins.Requester.GetJSON(j.Base, &custom, map[string]string{"tree": "builds[" + strings.Join(fields, ",") + "]"})
+	_, err := j.Jenkins.Requester.GetJSON(ctx, j.Base, &custom, map[string]string{"tree": "builds[" + strings.Join(fields, ",") + "]"})
 	if err != nil {
 		return err
 	}
@@ -205,11 +206,11 @@ func (j *Job) GetBuildsFields(fields []string, custom interface{}) error {
 }
 
 // Returns All Builds with Number and URL
-func (j *Job) GetAllBuildIds() ([]JobBuild, error) {
+func (j *Job) GetAllBuildIds(ctx context.Context) ([]JobBuild, error) {
 	var buildsResp struct {
 		Builds []JobBuild `json:"allBuilds"`
 	}
-	_, err := j.Jenkins.Requester.GetJSON(j.Base, &buildsResp, map[string]string{"tree": "allBuilds[number,url]"})
+	_, err := j.Jenkins.Requester.GetJSON(ctx, j.Base, &buildsResp, map[string]string{"tree": "allBuilds[number,url]"})
 	if err != nil {
 		return nil, err
 	}
@@ -228,10 +229,10 @@ func (j *Job) GetInnerJobsMetadata() []InnerJob {
 	return j.Raw.Jobs
 }
 
-func (j *Job) GetUpstreamJobs() ([]*Job, error) {
+func (j *Job) GetUpstreamJobs(ctx context.Context) ([]*Job, error) {
 	jobs := make([]*Job, len(j.Raw.UpstreamProjects))
 	for i, job := range j.Raw.UpstreamProjects {
-		ji, err := j.Jenkins.GetJob(job.Name)
+		ji, err := j.Jenkins.GetJob(ctx, job.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -240,10 +241,10 @@ func (j *Job) GetUpstreamJobs() ([]*Job, error) {
 	return jobs, nil
 }
 
-func (j *Job) GetDownstreamJobs() ([]*Job, error) {
+func (j *Job) GetDownstreamJobs(ctx context.Context) ([]*Job, error) {
 	jobs := make([]*Job, len(j.Raw.DownstreamProjects))
 	for i, job := range j.Raw.DownstreamProjects {
-		ji, err := j.Jenkins.GetJob(job.Name)
+		ji, err := j.Jenkins.GetJob(ctx, job.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -252,9 +253,9 @@ func (j *Job) GetDownstreamJobs() ([]*Job, error) {
 	return jobs, nil
 }
 
-func (j *Job) GetInnerJob(id string) (*Job, error) {
+func (j *Job) GetInnerJob(ctx context.Context, id string) (*Job, error) {
 	job := Job{Jenkins: j.Jenkins, Raw: new(JobResponse), Base: j.Base + "/job/" + id}
-	status, err := job.Poll()
+	status, err := job.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -264,10 +265,10 @@ func (j *Job) GetInnerJob(id string) (*Job, error) {
 	return nil, errors.New(strconv.Itoa(status))
 }
 
-func (j *Job) GetInnerJobs() ([]*Job, error) {
+func (j *Job) GetInnerJobs(ctx context.Context) ([]*Job, error) {
 	jobs := make([]*Job, len(j.Raw.Jobs))
 	for i, job := range j.Raw.Jobs {
-		ji, err := j.GetInnerJob(job.Name)
+		ji, err := j.GetInnerJob(ctx, job.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -276,8 +277,8 @@ func (j *Job) GetInnerJobs() ([]*Job, error) {
 	return jobs, nil
 }
 
-func (j *Job) Enable() (bool, error) {
-	resp, err := j.Jenkins.Requester.Post(j.Base+"/enable", nil, nil, nil)
+func (j *Job) Enable(ctx context.Context) (bool, error) {
+	resp, err := j.Jenkins.Requester.Post(ctx, j.Base+"/enable", nil, nil, nil)
 	if err != nil {
 		return false, err
 	}
@@ -287,8 +288,8 @@ func (j *Job) Enable() (bool, error) {
 	return true, nil
 }
 
-func (j *Job) Disable() (bool, error) {
-	resp, err := j.Jenkins.Requester.Post(j.Base+"/disable", nil, nil, nil)
+func (j *Job) Disable(ctx context.Context) (bool, error) {
+	resp, err := j.Jenkins.Requester.Post(ctx, j.Base+"/disable", nil, nil, nil)
 	if err != nil {
 		return false, err
 	}
@@ -298,8 +299,8 @@ func (j *Job) Disable() (bool, error) {
 	return true, nil
 }
 
-func (j *Job) Delete() (bool, error) {
-	resp, err := j.Jenkins.Requester.Post(j.Base+"/doDelete", nil, nil, nil)
+func (j *Job) Delete(ctx context.Context) (bool, error) {
+	resp, err := j.Jenkins.Requester.Post(ctx, j.Base+"/doDelete", nil, nil, nil)
 	if err != nil {
 		return false, err
 	}
@@ -309,41 +310,41 @@ func (j *Job) Delete() (bool, error) {
 	return true, nil
 }
 
-func (j *Job) Rename(name string) (bool, error) {
+func (j *Job) Rename(ctx context.Context, name string) (bool, error) {
 	data := url.Values{}
 	data.Set("newName", name)
-	_, err := j.Jenkins.Requester.Post(j.Base+"/doRename", bytes.NewBufferString(data.Encode()), nil, nil)
+	_, err := j.Jenkins.Requester.Post(ctx, j.Base+"/doRename", bytes.NewBufferString(data.Encode()), nil, nil)
 	if err != nil {
 		return false, err
 	}
 	return true, nil
 }
 
-func (j *Job) Create(config string, qr ...interface{}) (*Job, error) {
+func (j *Job) Create(ctx context.Context, config string, qr ...interface{}) (*Job, error) {
 	var querystring map[string]string
 	if len(qr) > 0 {
 		querystring = qr[0].(map[string]string)
 	}
-	resp, err := j.Jenkins.Requester.PostXML(j.parentBase()+"/createItem", config, j.Raw, querystring)
+	resp, err := j.Jenkins.Requester.PostXML(ctx, j.parentBase()+"/createItem", config, j.Raw, querystring)
 	if err != nil {
 		return nil, err
 	}
 	if resp.StatusCode == 200 {
-		j.Poll()
+		j.Poll(ctx)
 		return j, nil
 	}
 	return nil, errors.New(strconv.Itoa(resp.StatusCode))
 }
 
-func (j *Job) Copy(destinationName string) (*Job, error) {
+func (j *Job) Copy(ctx context.Context, destinationName string) (*Job, error) {
 	qr := map[string]string{"name": destinationName, "from": j.GetName(), "mode": "copy"}
-	resp, err := j.Jenkins.Requester.Post(j.parentBase()+"/createItem", nil, nil, qr)
+	resp, err := j.Jenkins.Requester.Post(ctx, j.parentBase()+"/createItem", nil, nil, qr)
 	if err != nil {
 		return nil, err
 	}
 	if resp.StatusCode == 200 {
 		newJob := &Job{Jenkins: j.Jenkins, Raw: new(JobResponse), Base: "/job/" + destinationName}
-		_, err := newJob.Poll()
+		_, err := newJob.Poll(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -352,33 +353,33 @@ func (j *Job) Copy(destinationName string) (*Job, error) {
 	return nil, errors.New(strconv.Itoa(resp.StatusCode))
 }
 
-func (j *Job) UpdateConfig(config string) error {
+func (j *Job) UpdateConfig(ctx context.Context, config string) error {
 
 	var querystring map[string]string
 
-	resp, err := j.Jenkins.Requester.PostXML(j.Base+"/config.xml", config, nil, querystring)
+	resp, err := j.Jenkins.Requester.PostXML(ctx, j.Base+"/config.xml", config, nil, querystring)
 	if err != nil {
 		return err
 	}
 	if resp.StatusCode == 200 {
-		j.Poll()
+		j.Poll(ctx)
 		return nil
 	}
 	return errors.New(strconv.Itoa(resp.StatusCode))
 
 }
 
-func (j *Job) GetConfig() (string, error) {
+func (j *Job) GetConfig(ctx context.Context) (string, error) {
 	var data string
-	_, err := j.Jenkins.Requester.GetXML(j.Base+"/config.xml", &data, nil)
+	_, err := j.Jenkins.Requester.GetXML(ctx, j.Base+"/config.xml", &data, nil)
 	if err != nil {
 		return "", err
 	}
 	return data, nil
 }
 
-func (j *Job) GetParameters() ([]ParameterDefinition, error) {
-	_, err := j.Poll()
+func (j *Job) GetParameters(ctx context.Context) ([]ParameterDefinition, error) {
+	_, err := j.Poll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -389,26 +390,26 @@ func (j *Job) GetParameters() ([]ParameterDefinition, error) {
 	return parameters, nil
 }
 
-func (j *Job) IsQueued() (bool, error) {
-	if _, err := j.Poll(); err != nil {
+func (j *Job) IsQueued(ctx context.Context) (bool, error) {
+	if _, err := j.Poll(ctx); err != nil {
 		return false, err
 	}
 	return j.Raw.InQueue, nil
 }
 
-func (j *Job) IsRunning() (bool, error) {
-	if _, err := j.Poll(); err != nil {
+func (j *Job) IsRunning(ctx context.Context) (bool, error) {
+	if _, err := j.Poll(ctx); err != nil {
 		return false, err
 	}
-	lastBuild, err := j.GetLastBuild()
+	lastBuild, err := j.GetLastBuild(ctx)
 	if err != nil {
 		return false, err
 	}
-	return lastBuild.IsRunning(), nil
+	return lastBuild.IsRunning(ctx), nil
 }
 
-func (j *Job) IsEnabled() (bool, error) {
-	if _, err := j.Poll(); err != nil {
+func (j *Job) IsEnabled(ctx context.Context) (bool, error) {
+	if _, err := j.Poll(ctx); err != nil {
 		return false, err
 	}
 	return j.Raw.Color != "disabled", nil
@@ -418,8 +419,8 @@ func (j *Job) HasQueuedBuild() {
 	panic("Not Implemented yet")
 }
 
-func (j *Job) InvokeSimple(params map[string]string) (int64, error) {
-	isQueued, err := j.IsQueued()
+func (j *Job) InvokeSimple(ctx context.Context, params map[string]string) (int64, error) {
+	isQueued, err := j.IsQueued(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -429,7 +430,7 @@ func (j *Job) InvokeSimple(params map[string]string) (int64, error) {
 	}
 
 	endpoint := "/build"
-	parameters, err := j.GetParameters()
+	parameters, err := j.GetParameters(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -440,7 +441,7 @@ func (j *Job) InvokeSimple(params map[string]string) (int64, error) {
 	for k, v := range params {
 		data.Set(k, v)
 	}
-	resp, err := j.Jenkins.Requester.Post(j.Base+endpoint, bytes.NewBufferString(data.Encode()), nil, nil)
+	resp, err := j.Jenkins.Requester.Post(ctx, j.Base+endpoint, bytes.NewBufferString(data.Encode()), nil, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -467,8 +468,8 @@ func (j *Job) InvokeSimple(params map[string]string) (int64, error) {
 	return number, nil
 }
 
-func (j *Job) Invoke(files []string, skipIfRunning bool, params map[string]string, cause string, securityToken string) (bool, error) {
-	isQueued, err := j.IsQueued()
+func (j *Job) Invoke(ctx context.Context, files []string, skipIfRunning bool, params map[string]string, cause string, securityToken string) (bool, error) {
+	isQueued, err := j.IsQueued(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -476,7 +477,7 @@ func (j *Job) Invoke(files []string, skipIfRunning bool, params map[string]strin
 		Error.Printf("%s is already running", j.GetName())
 		return false, nil
 	}
-	isRunning, err := j.IsRunning()
+	isRunning, err := j.IsRunning(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -505,7 +506,7 @@ func (j *Job) Invoke(files []string, skipIfRunning bool, params map[string]strin
 
 	buildParams["json"] = string(makeJson(params))
 	b, _ := json.Marshal(buildParams)
-	resp, err := j.Jenkins.Requester.PostFiles(j.Base+base, bytes.NewBuffer(b), nil, reqParams, files)
+	resp, err := j.Jenkins.Requester.PostFiles(ctx, j.Base+base, bytes.NewBuffer(b), nil, reqParams, files)
 	if err != nil {
 		return false, err
 	}
@@ -515,17 +516,17 @@ func (j *Job) Invoke(files []string, skipIfRunning bool, params map[string]strin
 	return false, errors.New(strconv.Itoa(resp.StatusCode))
 }
 
-func (j *Job) Poll() (int, error) {
-	response, err := j.Jenkins.Requester.GetJSON(j.Base, j.Raw, nil)
+func (j *Job) Poll(ctx context.Context) (int, error) {
+	response, err := j.Jenkins.Requester.GetJSON(ctx, j.Base, j.Raw, nil)
 	if err != nil {
 		return 0, err
 	}
 	return response.StatusCode, nil
 }
 
-func (j *Job) History() ([]*History, error) {
+func (j *Job) History(ctx context.Context) ([]*History, error) {
 	var s string
-	_, err := j.Jenkins.Requester.Get(j.Base+"/buildHistory/ajax", &s, nil)
+	_, err := j.Jenkins.Requester.Get(ctx, j.Base+"/buildHistory/ajax", &s, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -533,8 +534,8 @@ func (j *Job) History() ([]*History, error) {
 	return parseBuildHistory(strings.NewReader(s)), nil
 }
 
-func (pr *PipelineRun) ProceedInput() (bool, error) {
-	actions, _ := pr.GetPendingInputActions()
+func (pr *PipelineRun) ProceedInput(ctx context.Context) (bool, error) {
+	actions, _ := pr.GetPendingInputActions(ctx)
 	data := url.Values{}
 	data.Set("inputId", actions[0].ID)
 	params := make(map[string]string)
@@ -542,7 +543,7 @@ func (pr *PipelineRun) ProceedInput() (bool, error) {
 
 	href := pr.Base + "/wfapi/inputSubmit"
 
-	resp, err := pr.Job.Jenkins.Requester.Post(href, bytes.NewBufferString(data.Encode()), nil, nil)
+	resp, err := pr.Job.Jenkins.Requester.Post(ctx, href, bytes.NewBufferString(data.Encode()), nil, nil)
 	if err != nil {
 		return false, err
 	}
@@ -552,15 +553,15 @@ func (pr *PipelineRun) ProceedInput() (bool, error) {
 	return true, nil
 }
 
-func (pr *PipelineRun) AbortInput() (bool, error) {
-	actions, _ := pr.GetPendingInputActions()
+func (pr *PipelineRun) AbortInput(ctx context.Context) (bool, error) {
+	actions, _ := pr.GetPendingInputActions(ctx)
 	data := url.Values{}
 	params := make(map[string]string)
 	data.Set("json", makeJson(params))
 
 	href := pr.Base + "/input/" + actions[0].ID + "/abort"
 
-	resp, err := pr.Job.Jenkins.Requester.Post(href, bytes.NewBufferString(data.Encode()), nil, nil)
+	resp, err := pr.Job.Jenkins.Requester.Post(ctx, href, bytes.NewBufferString(data.Encode()), nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/label.go
+++ b/label.go
@@ -14,6 +14,8 @@
 
 package gojenkins
 
+import "context"
+
 type Label struct {
 	Raw     *LabelResponse
 	Jenkins *Jenkins
@@ -53,8 +55,8 @@ func (l *Label) GetNodes() []LabelNode {
 	return l.Raw.Nodes
 }
 
-func (l *Label) Poll() (int, error) {
-	response, err := l.Jenkins.Requester.GetJSON(l.Base, l.Raw, nil)
+func (l *Label) Poll(ctx context.Context) (int, error) {
+	response, err := l.Jenkins.Requester.GetJSON(ctx, l.Base, l.Raw, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/pipeline.go
+++ b/pipeline.go
@@ -18,6 +18,7 @@
 package gojenkins
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 )
@@ -97,8 +98,8 @@ func (run *PipelineRun) update() {
 	}
 }
 
-func (job *Job) GetPipelineRuns() (pr []PipelineRun, err error) {
-	_, err = job.Jenkins.Requester.GetJSON(job.Base+"/wfapi/runs", &pr, nil)
+func (job *Job) GetPipelineRuns(ctx context.Context) (pr []PipelineRun, err error) {
+	_, err = job.Jenkins.Requester.GetJSON(ctx, job.Base+"/wfapi/runs", &pr, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -110,10 +111,10 @@ func (job *Job) GetPipelineRuns() (pr []PipelineRun, err error) {
 	return pr, nil
 }
 
-func (job *Job) GetPipelineRun(id string) (pr *PipelineRun, err error) {
+func (job *Job) GetPipelineRun(ctx context.Context, id string) (pr *PipelineRun, err error) {
 	pr = new(PipelineRun)
 	href := job.Base + "/" + id + "/wfapi/describe"
-	_, err = job.Jenkins.Requester.GetJSON(href, pr, nil)
+	_, err = job.Jenkins.Requester.GetJSON(ctx, href, pr, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -123,10 +124,10 @@ func (job *Job) GetPipelineRun(id string) (pr *PipelineRun, err error) {
 	return pr, nil
 }
 
-func (pr *PipelineRun) GetPendingInputActions() (PIAs []PipelineInputAction, err error) {
+func (pr *PipelineRun) GetPendingInputActions(ctx context.Context) (PIAs []PipelineInputAction, err error) {
 	PIAs = make([]PipelineInputAction, 0, 1)
 	href := pr.Base + "/wfapi/pendingInputActions"
-	_, err = pr.Job.Jenkins.Requester.GetJSON(href, &PIAs, nil)
+	_, err = pr.Job.Jenkins.Requester.GetJSON(ctx, href, &PIAs, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -134,10 +135,10 @@ func (pr *PipelineRun) GetPendingInputActions() (PIAs []PipelineInputAction, err
 	return PIAs, nil
 }
 
-func (pr *PipelineRun) GetArtifacts() (artifacts []PipelineArtifact, err error) {
+func (pr *PipelineRun) GetArtifacts(ctx context.Context) (artifacts []PipelineArtifact, err error) {
 	artifacts = make([]PipelineArtifact, 0, 0)
 	href := pr.Base + "/wfapi/artifacts"
-	_, err = pr.Job.Jenkins.Requester.GetJSON(href, artifacts, nil)
+	_, err = pr.Job.Jenkins.Requester.GetJSON(ctx, href, artifacts, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -145,10 +146,10 @@ func (pr *PipelineRun) GetArtifacts() (artifacts []PipelineArtifact, err error) 
 	return artifacts, nil
 }
 
-func (pr *PipelineRun) GetNode(id string) (node *PipelineNode, err error) {
+func (pr *PipelineRun) GetNode(ctx context.Context, id string) (node *PipelineNode, err error) {
 	node = new(PipelineNode)
 	href := pr.Base + "/execution/node/" + id + "/wfapi/describe"
-	_, err = pr.Job.Jenkins.Requester.GetJSON(href, node, nil)
+	_, err = pr.Job.Jenkins.Requester.GetJSON(ctx, href, node, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -156,11 +157,11 @@ func (pr *PipelineRun) GetNode(id string) (node *PipelineNode, err error) {
 	return node, nil
 }
 
-func (node *PipelineNode) GetLog() (log *PipelineNodeLog, err error) {
+func (node *PipelineNode) GetLog(ctx context.Context) (log *PipelineNodeLog, err error) {
 	log = new(PipelineNodeLog)
 	href := node.Base + "/wfapi/log"
 	fmt.Println(href)
-	_, err = node.Run.Job.Jenkins.Requester.GetJSON(href, log, nil)
+	_, err = node.Run.Job.Jenkins.Requester.GetJSON(ctx, href, log, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -15,6 +15,7 @@
 package gojenkins
 
 import (
+	"context"
 	"strconv"
 )
 
@@ -63,11 +64,11 @@ func (p *Plugins) Contains(name string) *Plugin {
 	return nil
 }
 
-func (p *Plugins) Poll() (int, error) {
+func (p *Plugins) Poll(ctx context.Context) (int, error) {
 	qr := map[string]string{
 		"depth": strconv.Itoa(p.Depth),
 	}
-	response, err := p.Jenkins.Requester.GetJSON(p.Base, p.Raw, qr)
+	response, err := p.Jenkins.Requester.GetJSON(ctx, p.Base, p.Raw, qr)
 	if err != nil {
 		return 0, err
 	}

--- a/queue.go
+++ b/queue.go
@@ -15,6 +15,7 @@
 package gojenkins
 
 import (
+	"context"
 	"strconv"
 )
 
@@ -90,24 +91,24 @@ func (q *Queue) GetTasksForJob(name string) []*Task {
 	return tasks
 }
 
-func (q *Queue) CancelTask(id int64) (bool, error) {
+func (q *Queue) CancelTask(ctx context.Context, id int64) (bool, error) {
 	task := q.GetTaskById(id)
-	return task.Cancel()
+	return task.Cancel(ctx)
 }
 
-func (t *Task) Cancel() (bool, error) {
+func (t *Task) Cancel(ctx context.Context) (bool, error) {
 	qr := map[string]string{
 		"id": strconv.FormatInt(t.Raw.ID, 10),
 	}
-	response, err := t.Jenkins.Requester.Post(t.Jenkins.GetQueueUrl()+"/cancelItem", nil, t.Raw, qr)
+	response, err := t.Jenkins.Requester.Post(ctx, t.Jenkins.GetQueueUrl()+"/cancelItem", nil, t.Raw, qr)
 	if err != nil {
 		return false, err
 	}
 	return response.StatusCode == 200, nil
 }
 
-func (t *Task) GetJob() (*Job, error) {
-	return t.Jenkins.GetJob(t.Raw.Task.Name)
+func (t *Task) GetJob(ctx context.Context) (*Job, error) {
+	return t.Jenkins.GetJob(ctx, t.Raw.Task.Name)
 }
 
 func (t *Task) GetWhy() string {
@@ -132,16 +133,16 @@ func (t *Task) GetCauses() []map[string]interface{} {
 	return nil
 }
 
-func (q *Queue) Poll() (int, error) {
-	response, err := q.Jenkins.Requester.GetJSON(q.Base, q.Raw, nil)
+func (q *Queue) Poll(ctx context.Context) (int, error) {
+	response, err := q.Jenkins.Requester.GetJSON(ctx, q.Base, q.Raw, nil)
 	if err != nil {
 		return 0, err
 	}
 	return response.StatusCode, nil
 }
 
-func (t *Task) Poll() (int, error) {
-	response, err := t.Jenkins.Requester.GetJSON(t.Base, t.Raw, nil)
+func (t *Task) Poll(ctx context.Context) (int, error) {
+	response, err := t.Jenkins.Requester.GetJSON(ctx, t.Base, t.Raw, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/request.go
+++ b/request.go
@@ -16,13 +16,16 @@ package gojenkins
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"mime/multipart"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -59,9 +62,9 @@ type Requester struct {
 	SslVerify bool
 }
 
-func (r *Requester) SetCrumb(ar *APIRequest) error {
+func (r *Requester) SetCrumb(ctx context.Context, ar *APIRequest) error {
 	crumbData := map[string]string{}
-	response, _ := r.GetJSON("/crumbIssuer/api/json", &crumbData, nil)
+	response, _ := r.GetJSON(ctx, "/crumbIssuer/api/json", &crumbData, nil)
 
 	if response.StatusCode == 200 && crumbData["crumbRequestField"] != "" {
 		ar.SetHeader(crumbData["crumbRequestField"], crumbData["crumb"])
@@ -71,63 +74,63 @@ func (r *Requester) SetCrumb(ar *APIRequest) error {
 	return nil
 }
 
-func (r *Requester) PostJSON(endpoint string, payload io.Reader, responseStruct interface{}, querystring map[string]string) (*http.Response, error) {
+func (r *Requester) PostJSON(ctx context.Context, endpoint string, payload io.Reader, responseStruct interface{}, querystring map[string]string) (*http.Response, error) {
 	ar := NewAPIRequest("POST", endpoint, payload)
-	if err := r.SetCrumb(ar); err != nil {
+	if err := r.SetCrumb(ctx, ar); err != nil {
 		return nil, err
 	}
 	ar.SetHeader("Content-Type", "application/x-www-form-urlencoded")
 	ar.Suffix = "api/json"
-	return r.Do(ar, &responseStruct, querystring)
+	return r.Do(ctx, ar, &responseStruct, querystring)
 }
 
-func (r *Requester) Post(endpoint string, payload io.Reader, responseStruct interface{}, querystring map[string]string) (*http.Response, error) {
+func (r *Requester) Post(ctx context.Context, endpoint string, payload io.Reader, responseStruct interface{}, querystring map[string]string) (*http.Response, error) {
 	ar := NewAPIRequest("POST", endpoint, payload)
-	if err := r.SetCrumb(ar); err != nil {
+	if err := r.SetCrumb(ctx, ar); err != nil {
 		return nil, err
 	}
 	ar.SetHeader("Content-Type", "application/x-www-form-urlencoded")
 	ar.Suffix = ""
-	return r.Do(ar, &responseStruct, querystring)
+	return r.Do(ctx, ar, &responseStruct, querystring)
 }
 
-func (r *Requester) PostFiles(endpoint string, payload io.Reader, responseStruct interface{}, querystring map[string]string, files []string) (*http.Response, error) {
+func (r *Requester) PostFiles(ctx context.Context, endpoint string, payload io.Reader, responseStruct interface{}, querystring map[string]string, files []string) (*http.Response, error) {
 	ar := NewAPIRequest("POST", endpoint, payload)
-	if err := r.SetCrumb(ar); err != nil {
+	if err := r.SetCrumb(ctx, ar); err != nil {
 		return nil, err
 	}
-	return r.Do(ar, &responseStruct, querystring, files)
+	return r.Do(ctx, ar, &responseStruct, querystring, files)
 }
 
-func (r *Requester) PostXML(endpoint string, xml string, responseStruct interface{}, querystring map[string]string) (*http.Response, error) {
+func (r *Requester) PostXML(ctx context.Context, endpoint string, xml string, responseStruct interface{}, querystring map[string]string) (*http.Response, error) {
 	payload := bytes.NewBuffer([]byte(xml))
 	ar := NewAPIRequest("POST", endpoint, payload)
-	if err := r.SetCrumb(ar); err != nil {
+	if err := r.SetCrumb(ctx, ar); err != nil {
 		return nil, err
 	}
 	ar.SetHeader("Content-Type", "application/xml")
 	ar.Suffix = ""
-	return r.Do(ar, &responseStruct, querystring)
+	return r.Do(ctx, ar, &responseStruct, querystring)
 }
 
-func (r *Requester) GetJSON(endpoint string, responseStruct interface{}, query map[string]string) (*http.Response, error) {
+func (r *Requester) GetJSON(ctx context.Context, endpoint string, responseStruct interface{}, query map[string]string) (*http.Response, error) {
 	ar := NewAPIRequest("GET", endpoint, nil)
 	ar.SetHeader("Content-Type", "application/json")
 	ar.Suffix = "api/json"
-	return r.Do(ar, &responseStruct, query)
+	return r.Do(ctx, ar, &responseStruct, query)
 }
 
-func (r *Requester) GetXML(endpoint string, responseStruct interface{}, query map[string]string) (*http.Response, error) {
+func (r *Requester) GetXML(ctx context.Context, endpoint string, responseStruct interface{}, query map[string]string) (*http.Response, error) {
 	ar := NewAPIRequest("GET", endpoint, nil)
 	ar.SetHeader("Content-Type", "application/xml")
 	ar.Suffix = ""
-	return r.Do(ar, responseStruct, query)
+	return r.Do(ctx, ar, responseStruct, query)
 }
 
-func (r *Requester) Get(endpoint string, responseStruct interface{}, querystring map[string]string) (*http.Response, error) {
+func (r *Requester) Get(ctx context.Context, endpoint string, responseStruct interface{}, querystring map[string]string) (*http.Response, error) {
 	ar := NewAPIRequest("GET", endpoint, nil)
 	ar.Suffix = ""
-	return r.Do(ar, responseStruct, querystring)
+	return r.Do(ctx, ar, responseStruct, querystring)
 }
 
 func (r *Requester) SetClient(client *http.Client) *Requester {
@@ -143,7 +146,7 @@ func (r *Requester) redirectPolicyFunc(req *http.Request, via []*http.Request) e
 	return nil
 }
 
-func (r *Requester) Do(ar *APIRequest, responseStruct interface{}, options ...interface{}) (*http.Response, error) {
+func (r *Requester) Do(ctx context.Context, ar *APIRequest, responseStruct interface{}, options ...interface{}) (*http.Response, error) {
 	if !strings.HasSuffix(ar.Endpoint, "/") && ar.Method != "POST" {
 		ar.Endpoint += "/"
 	}
@@ -227,6 +230,13 @@ func (r *Requester) Do(ar *APIRequest, responseStruct interface{}, options ...in
 	if response, err := r.Client.Do(req); err != nil {
 		return nil, err
 	} else {
+		if v := ctx.Value("debug"); v != nil {
+			dump, err := httputil.DumpResponse(response, true)
+			if err != nil {
+				log.Fatal(err)
+			}
+			log.Printf("DEBUG %q\n", dump)
+		}
 		errorText := response.Header.Get("X-Error")
 		if errorText != "" {
 			return nil, errors.New(errorText)

--- a/views.go
+++ b/views.go
@@ -15,6 +15,7 @@
 package gojenkins
 
 import (
+	"context"
 	"errors"
 	"strconv"
 )
@@ -42,10 +43,10 @@ var (
 )
 
 // Returns True if successfully added Job, otherwise false
-func (v *View) AddJob(name string) (bool, error) {
+func (v *View) AddJob(ctx context.Context, name string) (bool, error) {
 	url := "/addJobToView"
 	qr := map[string]string{"name": name}
-	resp, err := v.Jenkins.Requester.Post(v.Base+url, nil, nil, qr)
+	resp, err := v.Jenkins.Requester.Post(ctx, v.Base+url, nil, nil, qr)
 	if err != nil {
 		return false, err
 	}
@@ -56,10 +57,10 @@ func (v *View) AddJob(name string) (bool, error) {
 }
 
 // Returns True if successfully deleted Job, otherwise false
-func (v *View) DeleteJob(name string) (bool, error) {
+func (v *View) DeleteJob(ctx context.Context, name string) (bool, error) {
 	url := "/removeJobFromView"
 	qr := map[string]string{"name": name}
-	resp, err := v.Jenkins.Requester.Post(v.Base+url, nil, nil, qr)
+	resp, err := v.Jenkins.Requester.Post(ctx, v.Base+url, nil, nil, qr)
 	if err != nil {
 		return false, err
 	}
@@ -85,8 +86,8 @@ func (v *View) GetUrl() string {
 	return v.Raw.URL
 }
 
-func (v *View) Poll() (int, error) {
-	response, err := v.Jenkins.Requester.GetJSON(v.Base, v.Raw, nil)
+func (v *View) Poll(ctx context.Context) (int, error) {
+	response, err := v.Jenkins.Requester.GetJSON(ctx, v.Base, v.Raw, nil)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
1) Add context in functions to make debugging easier

    if "debug" been set in context, will dump response data including body.
    we can pass logger in context in the future

2) Add GetBuildFromQueueID() function

    a) This function going to return the build object base on task/queue id.
    Jenkins will queue a task for a few second and assign the build number.

    b) Update REAME file for use case of triggering a job and get the result of the build.
    Update README with context paramete

    Signed-off-by: Hui Luo <luoh@vmware.com>