### PR TITLE
Added function to fetch run log

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -157,10 +157,20 @@ func (pr *PipelineRun) GetNode(ctx context.Context, id string) (node *PipelineNo
 	return node, nil
 }
 
+func (pr *PipelineRun) GetConsoleLog(id string) (log string, err error) {
+	href := pr.Base + "/execution/node/" + id + "/log"
+	var log string
+	_, err = pr.Job.Jenkins.Requester.GetXML(href, &log, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return log, nil
+}
+
 func (node *PipelineNode) GetLog(ctx context.Context) (log *PipelineNodeLog, err error) {
 	log = new(PipelineNodeLog)
 	href := node.Base + "/wfapi/log"
-	fmt.Println(href)
 	_, err = node.Run.Job.Jenkins.Requester.GetJSON(ctx, href, log, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This patch is about fetching console logs for a Jenkins job run.