### PR TITLE
Allow running the same job multiple times concurrently

### DIFF
--- a/job.go
+++ b/job.go
@@ -420,15 +420,6 @@ func (j *Job) HasQueuedBuild() {
 }
 
 func (j *Job) InvokeSimple(ctx context.Context, params map[string]string) (int64, error) {
-	isQueued, err := j.IsQueued(ctx)
-	if err != nil {
-		return 0, err
-	}
-	if isQueued {
-		Error.Printf("%s is already running", j.GetName())
-		return 0, nil
-	}
-
 	endpoint := "/build"
 	parameters, err := j.GetParameters(ctx)
 	if err != nil {


### PR DESCRIPTION
I am not sure why this code was included originally. It prevents invoking a job multiple times with different parameters.