### PR TITLE
Fixing the GetBuild() url path for customized domain

### DIFF
--- a/job.go
+++ b/job.go
@@ -122,10 +122,10 @@ func (j *Job) GetDetails() *JobResponse {
 
 func (j *Job) GetBuild(ctx context.Context, id int64) (*Build, error) {
 
-	// url.Path does not work when you have a customized domai
-	// Ex: Server : https://<domain>/jenkins/job/JOB1
-	// In the above example /jenkins is part fo the domain name
-	// url.Path returns /jenkins/job/JOB1 instead of expected /job/JOB1
+	// Support customized server URL,
+	// i.e. Server : https://<domain>/jenkins/job/JOB1
+	// "https://<domain>/jenkins/" is the server URL,
+	// we are expecting jobURL = "job/JOB1"
 	jobURL := strings.Replace(j.Raw.URL,j.Jenkins.Server,"",-1)
 	build := Build{Jenkins: j.Jenkins, Job: j, Raw: new(BuildResponse), Depth: 1, Base: jobURL + "/" + strconv.FormatInt(id, 10)}
 	status, err := build.Poll(ctx)

--- a/job.go
+++ b/job.go
@@ -121,12 +121,12 @@ func (j *Job) GetDetails() *JobResponse {
 }
 
 func (j *Job) GetBuild(ctx context.Context, id int64) (*Build, error) {
-	// use job embedded URL to properly handle jobs in folders
-	url, err := url.Parse(j.Raw.URL)
-	if err != nil {
-		return nil, err
-	}
-	jobURL := url.Path
+
+	// url.Path does not work when you have a customized domai
+	// Ex: Server : https://<domain>/jenkins/job/JOB1
+	// In the above example /jenkins is part fo the domain name
+	// url.Path returns /jenkins/job/JOB1 instead of expected /job/JOB1
+	jobURL := strings.Replace(j.Raw.URL,j.Jenkins.Server,"",-1)
 	build := Build{Jenkins: j.Jenkins, Job: j, Raw: new(BuildResponse), Depth: 1, Base: jobURL + "/" + strconv.FormatInt(id, 10)}
 	status, err := build.Poll(ctx)
 	if err != nil {


### PR DESCRIPTION
GetBuild() fails when the jenkins domain name is not https://localhost:<port>
 If jenkins is being accessed like this https://domain/jenkins , here /jenkins is part of the server path

In the above case the job url would like this
 https://domain/jenkins/job/JOB1

and url.Path would return /jenkins/job/JOB1 instead of job/JOB1 because of the GetPoll() fails since its polling  https://domain/jenkins/jenkins/job/JOB1/api/json instead of https://domain/jenkins/job/JOB1/api/json