### PR TITLE
Added support for secret file credentials.

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -55,6 +55,17 @@ type StringCredentials struct {
 	Secret      string   `xml:"secret"`
 }
 
+//FileCredentials store a file
+//"SecretBytes" is a base64 encoded file content
+type FileCredentials struct {
+	XMLName     xml.Name `xml:"org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl"`
+	ID          string   `xml:"id"`
+	Scope       string   `xml:"scope"`
+	Description string   `xml:"description"`
+	Filename    string   `xml:"fileName"`
+	SecretBytes string   `xml:"secretBytes"`
+}
+
 //SSHCredentials store credentials for ssh keys.
 type SSHCredentials struct {
 	XMLName          xml.Name    `xml:"com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey"`

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -14,6 +14,7 @@ var (
 	dockerID   = "dockerIDCred"
 	sshID      = "sshIdCred"
 	usernameID = "usernameIDcred"
+	fileID     = "fileIDcred"
 	scope      = "GLOBAL"
 )
 
@@ -37,6 +38,28 @@ func TestCreateUsernameCredentials(t *testing.T) {
 	assert.Equal(t, cred.Scope, getCred.Scope, "Scope is not equal")
 	assert.Equal(t, cred.ID, cred.ID, "ID is not equal")
 	assert.Equal(t, cred.Username, cred.Username, "Username is not equal")
+}
+
+func TestCreateFileCredentials(t *testing.T) {
+
+	cred := FileCredentials{
+		ID:          fileID,
+		Scope:       scope,
+		Filename:    "testFile.json",
+		SecretBytes: "VGhpcyBpcyBhIHRlc3Qu\n",
+	}
+
+	ctx := context.Background()
+	err := cm.Add(ctx, domain, cred)
+	assert.Nil(t, err, "Could not create credential")
+
+	getCred := FileCredentials{}
+	err = cm.GetSingle(ctx, domain, cred.ID, &getCred)
+	assert.Nil(t, err, "Could not get credential")
+
+	assert.Equal(t, cred.Scope, getCred.Scope, "Scope is not equal")
+	assert.Equal(t, cred.ID, cred.ID, "ID is not equal")
+	assert.Equal(t, cred.Filename, cred.Filename, "Filename is not equal")
 }
 
 func TestCreateDockerCredentials(t *testing.T) {

--- a/job.go
+++ b/job.go
@@ -126,7 +126,7 @@ func (j *Job) GetBuild(ctx context.Context, id int64) (*Build, error) {
 	// i.e. Server : https://<domain>/jenkins/job/JOB1
 	// "https://<domain>/jenkins/" is the server URL,
 	// we are expecting jobURL = "job/JOB1"
-	jobURL := strings.Replace(j.Raw.URL,j.Jenkins.Server,"",-1)
+	jobURL := strings.Replace(j.Raw.URL, j.Jenkins.Server, "", -1)
 	build := Build{Jenkins: j.Jenkins, Job: j, Raw: new(BuildResponse), Depth: 1, Base: jobURL + "/" + strconv.FormatInt(id, 10)}
 	status, err := build.Poll(ctx)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Jacek Kikiewicz <public@kikiewicz.com>

I added support for secret file, as well as test for it.
Additionally I tested this locally (as in  via go test as in .travis.yml) and in a job manually and all looks good from my side.