### PR TITLE
Support for Bearer Auth (API Token)

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -33,6 +33,10 @@ type BasicAuth struct {
 	Password string
 }
 
+type BearerAuth struct {
+	Token string
+}
+
 type Jenkins struct {
 	Server    string
 	Version   string
@@ -593,8 +597,11 @@ func (j *Jenkins) Poll(ctx context.Context) (int, error) {
 	return resp.StatusCode, nil
 }
 
-// Creates a new Jenkins Instance
-// Optional parameters are: client, username, password or token
+// Creates a new Jenkins Instance using client and base
+// Optional parameters are either
+//  - username & password for basic auth
+// or
+//  - token for bearer auth
 // After creating an instance call init method.
 func CreateJenkins(client *http.Client, base string, auth ...interface{}) *Jenkins {
 	j := &Jenkins{}
@@ -608,6 +615,9 @@ func CreateJenkins(client *http.Client, base string, auth ...interface{}) *Jenki
 	}
 	if len(auth) == 2 {
 		j.Requester.BasicAuth = &BasicAuth{Username: auth[0].(string), Password: auth[1].(string)}
+	}
+	if len(auth) == 1 {
+		j.Requester.BearerAuth = &BearerAuth{Token: auth[0].(string)}
 	}
 	return j
 }

--- a/request.go
+++ b/request.go
@@ -55,11 +55,12 @@ func NewAPIRequest(method string, endpoint string, payload io.Reader) *APIReques
 }
 
 type Requester struct {
-	Base      string
-	BasicAuth *BasicAuth
-	Client    *http.Client
-	CACert    []byte
-	SslVerify bool
+	Base       string
+	BasicAuth  *BasicAuth
+	BearerAuth *BearerAuth
+	Client     *http.Client
+	CACert     []byte
+	SslVerify  bool
 }
 
 func (r *Requester) SetCrumb(ctx context.Context, ar *APIRequest) error {
@@ -143,6 +144,9 @@ func (r *Requester) redirectPolicyFunc(req *http.Request, via []*http.Request) e
 	if r.BasicAuth != nil {
 		req.SetBasicAuth(r.BasicAuth.Username, r.BasicAuth.Password)
 	}
+	if r.BearerAuth != nil {
+		req.Header.Add("Authorization", "Bearer "+r.BearerAuth.Token)
+	}
 	return nil
 }
 
@@ -221,6 +225,10 @@ func (r *Requester) Do(ctx context.Context, ar *APIRequest, responseStruct inter
 
 	if r.BasicAuth != nil {
 		req.SetBasicAuth(r.BasicAuth.Username, r.BasicAuth.Password)
+	}
+
+	if r.BearerAuth != nil {
+		req.Header.Add("Authorization", "Bearer "+r.BearerAuth.Token)
 	}
 
 	for k := range ar.Headers {


### PR DESCRIPTION
Hi,

this PR adds support for Bearer Authentication. Bearer Authentication is used when only one string is passed to the CreateJenkins method

```go
gojenkins.CreateJenkins(nil, "http://localhost/", "<api-token>")
```

Thanks, Fabian