### PR TITLE
enable utf-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.a
 *.so
 .idea/
+.vscode/
 
 # Folders
 _obj

--- a/request.go
+++ b/request.go
@@ -108,7 +108,7 @@ func (r *Requester) PostXML(ctx context.Context, endpoint string, xml string, re
 	if err := r.SetCrumb(ctx, ar); err != nil {
 		return nil, err
 	}
-	ar.SetHeader("Content-Type", "application/xml")
+	ar.SetHeader("Content-Type", "application/xml;charset=utf-8")
 	ar.Suffix = ""
 	return r.Do(ctx, ar, &responseStruct, querystring)
 }


### PR DESCRIPTION
1. when I update job parameter description which contains Chinese characters，the Chinese characters will become some garbled codes
2. just ignore`.vscode`