### PR TITLE
fix: jenkins GetBuildFromQueueID return 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ For users that would like CLI based on gojenkins, follow the steps below:
 ## Usage
 
 ```go
-
 import (
   "github.com/bndr/gojenkins"
   "context"
@@ -53,12 +52,11 @@ if err != nil {
   panic("Something Went Wrong")
 }
 
-job := jenkins.GetJobObj(ctx, "#jobname")
-queueid, err := jenkins.InvokeSimple(ctx, params)
+queueid, err := jenkins.BuildJob(ctx, "#jobname", nil)
 if err != nil {
   panic(err)
 }
-build, err := jenkins.GetBuildFromQueueID(ctx, job, queueid)
+build, err := jenkins.GetBuildFromQueueID(ctx, queueid)
 if err != nil {
   panic(err)
 }

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -137,7 +137,7 @@ func TestCreateSSHCredentialsFullFlow(t *testing.T) {
 func TestMain(m *testing.M) {
 	//setup
 	ctx := context.Background()
-	jenkins := CreateJenkins(nil, "http://localhost:8080", "admin", "admin")
+	jenkins = CreateJenkins(nil, "http://localhost:8080", "admin", "admin")
 	jenkins.Init(ctx)
 
 	cm = &CredentialsManager{J: jenkins}

--- a/jenkins.go
+++ b/jenkins.go
@@ -279,7 +279,7 @@ func (j *Jenkins) BuildJob(ctx context.Context, name string, params map[string]s
 
 // A task in queue will be assigned a build number in a job after a few seconds.
 // this function will return the build object.
-func (j *Jenkins) GetBuildFromQueueID(ctx context.Context, job *Job, queueid int64) (*Build, error) {
+func (j *Jenkins) GetBuildFromQueueID(ctx context.Context, queueid int64) (*Build, error) {
 	task, err := j.GetQueueItem(ctx, queueid)
 	if err != nil {
 		return nil, err
@@ -292,8 +292,10 @@ func (j *Jenkins) GetBuildFromQueueID(ctx context.Context, job *Job, queueid int
 			return nil, err
 		}
 	}
-
-	build, err := job.GetBuild(ctx, task.Raw.Executable.Number)
+	buildid := task.Raw.Executable.Number
+	job := &Job{Jenkins: j, Raw: new(JobResponse)}
+	job.Raw.URL = strings.TrimSuffix(task.Raw.Task.URL, "/")
+	build, err := job.GetBuild(ctx, buildid)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1. credentials_test.go TestMain init global jenkins
2. jenkins `GetBuildFromQueueID` return 404
3. jenkins_test.go add `GetBuildFromQueueID` unit test function: `TestJenkins_GetBuildFromQueueID`
4. README.md modify `GetBuildFromQueueID` example