### PR TITLE
Update build_history.go

### DIFF
--- a/build_history.go
+++ b/build_history.go
@@ -73,6 +73,16 @@ func parseBuildHistory(d io.Reader) []*History {
 						}
 					}
 				}
+				//adapte   Jenkins 2.289.1 ,fix cant't get the buildstauts
+				if string(tn) == "use" {
+					if href, found := a["href"]; found {
+						if strings.HasPrefix(href, "/static/") {
+							parts := strings.Split(href, "#")
+							curBuild.BuildStatus = parts[1]
+
+						}
+					}
+				}
 			}
 		case html.TextToken:
 			if isInsideDisplayName {


### PR DESCRIPTION
adapte   Jenkins 2.289.1 ,fix can't get the buildstauts

the history format is 

`</a></div><div class="pane build-controls"><div class="middle-align build-badge"></div></div><div class="left-bar"></div></td></tr><tr page-entry-id="-9223372036854775778" class="build-row  single-line"><td class="build-row-cell"><div class="pane build-name"><div class="build-icon"><a href="/job/alltest_jp_backend/job/devops-cicd-uat/30/console" class="build-status-link"><span style="width: 16px; height: 16px; " class="build-status-icon__wrapper icon-blue icon-sm"><span class="build-status-icon__outer"><svg viewBox="0 0 24 24" focusable="false" class="svg-icon "><use href="/images/build-status/build-status-sprite.svg#build-status-static"></use></svg></span><svg viewBox="0 0 24 24" focusable="false" class="svg-icon icon-blue icon-sm"><use href="/static/11b4b60c/images/build-status/build-status-sprite.svg#last-successful"></use></svg></span></a></div><a update-parent-class=".build-row" href="/job/alltest_jp_backend/job/devops-cicd-uat/30/" class="tip model-link inside build-link display-name">#30</a></div><div time="1645776431474" class="pane build-details"><a update-parent-class=".build-row" tooltip="Took 2 min 47 sec" href="/job/alltest_jp_backend/job/devops-cicd-uat/30/" class="tip model-link inside build-link">Feb 25, 2022 8:07 AM `

@figo please merge,thanks