### PR TITLE
Fix README: Sample Code not working - 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,11 @@ if err != nil {
   panic("Something Went Wrong")
 }
 
-job := jenkins.GetJobObj(ctx, "#jobname")
-queueid, err := job.InvokeSimple(ctx, params)
+job, err := jenkins.GetJob(ctx, "#jobname")
+if err != nil {
+  panic(err)
+}
+queueid, err := job.InvokeSimple(ctx, params) // or  jenkins.BuildJob(ctx, "#jobname", params)
 if err != nil {
   panic(err)
 }


### PR DESCRIPTION
the sample code will complain with
```panic: 404```

because `job := jenkins.GetJobObj()`
the `job.Raw.URL` is blank, then inside `jenkins.GetBuildFromQueueID(ctx, job, queueid)`,
it will failed with 404

https://github.com/bndr/gojenkins/pull/259 also address it . but either way are ok. 

anyhow, I know nobody takes care of this community, but I just raise it here in case other people jumping into this hole.

