### PR TITLE
fix：complete PipelineNode Model, add property ParameterDescription

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -47,16 +47,17 @@ type PipelineRun struct {
 }
 
 type PipelineNode struct {
-	Run            *PipelineRun
-	Base           string
-	URLs           map[string]map[string]string `json:"_links"`
-	ID             string
-	Name           string
-	Status         string
-	StartTime      int64 `json:"startTimeMillis"`
-	Duration       int64 `json:"durationMillis"`
-	StageFlowNodes []PipelineNode
-	ParentNodes    []int64
+	Run                  *PipelineRun
+	Base                 string
+	URLs                 map[string]map[string]string `json:"_links"`
+	ID                   string
+	Name                 string
+	ParameterDescription string
+	Status               string
+	StartTime            int64 `json:"startTimeMillis"`
+	Duration             int64 `json:"durationMillis"`
+	StageFlowNodes       []PipelineNode
+	ParentNodes          []int64
 }
 
 type PipelineInputAction struct {


### PR DESCRIPTION
Add property  ParameterDescription to the model PipelineNode Model. In my case ,i need to show ParameterDescription to user. this is example response from jenkins，but gojenkins lack of the property .
![image](https://user-images.githubusercontent.com/14506118/186110548-4ca3267d-b9cb-4edc-994a-d66afc1ab52e.png)
