### PR TITLE
Abstract logging to an interface

### DIFF
--- a/artifact.go
+++ b/artifact.go
@@ -44,7 +44,7 @@ func (a Artifact) GetData(ctx context.Context) ([]byte, error) {
 
 	code := response.StatusCode
 	if code != 200 {
-		Error.Printf("Jenkins responded with StatusCode: %d", code)
+		Logger.Error("Jenkins responded with StatusCode: %d", code)
 		return nil, errors.New("Could not get File Contents")
 	}
 	return []byte(data), nil
@@ -59,7 +59,7 @@ func (a Artifact) Save(ctx context.Context, path string) (bool, error) {
 	}
 
 	if _, err = os.Stat(path); err == nil {
-		Warning.Println("Local Copy already exists, Overwriting...")
+		Logger.Warn("Local Copy already exists, Overwriting...")
 	}
 
 	err = ioutil.WriteFile(path, data, 0644)
@@ -74,7 +74,7 @@ func (a Artifact) Save(ctx context.Context, path string) (bool, error) {
 // Save Artifact to directory using Artifact filename.
 func (a Artifact) SaveToDir(ctx context.Context, dir string) (bool, error) {
 	if _, err := os.Stat(dir); err != nil {
-		Error.Printf("can't save artifact: directory %s does not exist", dir)
+		Logger.Error("can't save artifact: directory %s does not exist", dir)
 		return false, fmt.Errorf("can't save artifact: directory %s does not exist", dir)
 	}
 	saved, err := a.Save(ctx, path.Join(dir, a.FileName))

--- a/jenkins.go
+++ b/jenkins.go
@@ -40,18 +40,14 @@ type Jenkins struct {
 	Requester *Requester
 }
 
-// Loggers
-var (
-	Info    *log.Logger
-	Warning *log.Logger
-	Error   *log.Logger
-)
+// Main Logger
+var Logger LeveledLogger
 
 // Init Method. Should be called after creating a Jenkins Instance.
 // e.g jenkins,err := CreateJenkins("url").Init()
 // HTTP Client is set here, Connection to jenkins is tested here.
 func (j *Jenkins) Init(ctx context.Context) (*Jenkins, error) {
-	j.initLoggers()
+	j.initDefaultLogger()
 
 	// Check Connection
 	j.Raw = new(ExecutorResponse)
@@ -68,18 +64,24 @@ func (j *Jenkins) Init(ctx context.Context) (*Jenkins, error) {
 	return j, nil
 }
 
-func (j *Jenkins) initLoggers() {
-	Info = log.New(os.Stdout,
+func (j *Jenkins) initDefaultLogger() {
+	debug := log.New(os.Stdout,
+		"DEBUG: ",
+		log.Ldate|log.Ltime|log.Lshortfile)
+
+	info := log.New(os.Stdout,
 		"INFO: ",
 		log.Ldate|log.Ltime|log.Lshortfile)
 
-	Warning = log.New(os.Stdout,
+	warning := log.New(os.Stdout,
 		"WARNING: ",
 		log.Ldate|log.Ltime|log.Lshortfile)
 
-	Error = log.New(os.Stderr,
+	err := log.New(os.Stderr,
 		"ERROR: ",
 		log.Ldate|log.Ltime|log.Lshortfile)
+
+	Logger = NewLeveledLogger(debug, info, warning, err)
 }
 
 // Get Basic Information About Jenkins

--- a/job.go
+++ b/job.go
@@ -425,7 +425,7 @@ func (j *Job) InvokeSimple(ctx context.Context, params map[string]string) (int64
 		return 0, err
 	}
 	if isQueued {
-		Error.Printf("%s is already running", j.GetName())
+		Logger.Error("%s is already running", j.GetName())
 		return 0, nil
 	}
 
@@ -474,7 +474,7 @@ func (j *Job) Invoke(ctx context.Context, files []string, skipIfRunning bool, pa
 		return false, err
 	}
 	if isQueued {
-		Error.Printf("%s is already running", j.GetName())
+		Logger.Error("%s is already running", j.GetName())
 		return false, nil
 	}
 	isRunning, err := j.IsRunning(ctx)

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,71 @@
+// Copyright 2022 Dmitry Heraskou
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF interface{} KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Gojenkins is a Jenkins Client in Go, that exposes the jenkins REST api in a more developer friendly way.
+package gojenkins
+
+import "log"
+
+// Logger interface used by jenkins for loging
+type LeveledLogger interface {
+	Debug(format string, a ...interface{})
+	Info(format string, a ...interface{})
+	Warn(format string, a ...interface{})
+	Error(format string, a ...interface{})
+}
+
+// Simple implementation using golang log library
+type LeveledLoggerImpl struct {
+	debug   *log.Logger
+	info    *log.Logger
+	warning *log.Logger
+	err     *log.Logger
+}
+
+func NewLeveledLogger(debug, info, warn, err *log.Logger) LeveledLogger {
+	return &LeveledLoggerImpl{
+		debug:   debug,
+		info:    info,
+		warning: warn,
+		err:     err,
+	}
+}
+
+func (l *LeveledLoggerImpl) Debug(format string, a ...interface{}) {
+	if l == nil || l.debug == nil {
+		return
+	}
+	l.debug.Printf(format, a)
+}
+
+func (l *LeveledLoggerImpl) Info(format string, a ...interface{}) {
+	if l == nil || l.info == nil {
+		return
+	}
+	l.info.Printf(format, a)
+}
+
+func (l *LeveledLoggerImpl) Warn(format string, a ...interface{}) {
+	if l == nil || l.warning == nil {
+		return
+	}
+	l.warning.Printf(format, a)
+}
+
+func (l *LeveledLoggerImpl) Error(format string, a ...interface{}) {
+	if l == nil || l.err == nil {
+		return
+	}
+	l.err.Printf(format, a)
+}


### PR DESCRIPTION
Today log implementation is based on golang.log. This PR abstracts  logging to use an interface which allows any implementation to be used.