### PR TITLE
Add new method on job.go to get builds fields with filter

### DIFF
--- a/cli/jenkinsctl/cmd/create.go
+++ b/cli/jenkinsctl/cmd/create.go
@@ -19,9 +19,10 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"strconv"
+
+	"github.com/spf13/cobra"
 )
 
 // createCmd represents the create command

--- a/cli/jenkinsctl/cmd/delete.go
+++ b/cli/jenkinsctl/cmd/delete.go
@@ -19,8 +19,9 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // deleteCmd represents the delete command

--- a/cli/jenkinsctl/cmd/disable.go
+++ b/cli/jenkinsctl/cmd/disable.go
@@ -19,8 +19,9 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 var disableCmd = &cobra.Command{

--- a/cli/jenkinsctl/cmd/download.go
+++ b/cli/jenkinsctl/cmd/download.go
@@ -18,9 +18,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"strconv"
+
+	"github.com/spf13/cobra"
 )
 
 // downloadCmd represents the download command

--- a/cli/jenkinsctl/cmd/enable.go
+++ b/cli/jenkinsctl/cmd/enable.go
@@ -19,8 +19,9 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 var enableCmd = &cobra.Command{

--- a/cli/jenkinsctl/cmd/root.go
+++ b/cli/jenkinsctl/cmd/root.go
@@ -18,9 +18,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/dougsland/jenkinsctl/jenkins"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cli/jenkinsctl/jenkins/jenkins.go
+++ b/cli/jenkinsctl/jenkins/jenkins.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/bndr/gojenkins"
-	"github.com/spf13/viper"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/bndr/gojenkins"
+	"github.com/spf13/viper"
 )
 
 // Jenkins connection object
@@ -36,6 +37,7 @@ type Config struct {
 // Args:
 //
 // Returns
+//
 //	string or error
 func (j *Config) SetConfigPath(path string) {
 	dir, file := filepath.Split(path)
@@ -47,9 +49,11 @@ func (j *Config) SetConfigPath(path string) {
 // CheckIfExists check if file exists
 //
 // Args:
+//
 //	path - string
 //
 // Returns
+//
 //	error
 func (j *Config) CheckIfExists() error {
 	var err error
@@ -66,10 +70,10 @@ func (j *Config) CheckIfExists() error {
 //
 // $HOME/.config/jenkinsctl/config.json
 //
-//
 // Args:
 //
 // Returns
+//
 //	nil or error
 func (j *Config) LoadConfig() (config Config, err error) {
 	viper.AddConfigPath(j.ConfigPath)
@@ -89,6 +93,7 @@ func (j *Config) LoadConfig() (config Config, err error) {
 // PluginsShow show all plugins installed and enabled
 //
 // Returns
+//
 //	nil or error
 func (j *Jenkins) PluginsShow() {
 	p, _ := j.Instance.GetPlugins(j.Context, 1)
@@ -106,9 +111,11 @@ func (j *Jenkins) PluginsShow() {
 // DeleteJob will delete a job
 //
 // Args:
+//
 //	jobName - job name
 //
 // Returns:
+//
 //	error or nil
 func (j *Jenkins) DeleteJob(jobName string) error {
 	job, err := j.Instance.GetJob(j.Context, jobName)
@@ -124,9 +131,11 @@ func (j *Jenkins) DeleteJob(jobName string) error {
 // JobGetConfig get the configuration from job
 //
 // Args:
+//
 //	jobName - job name
 //
 // Returns:
+//
 //	error or nil
 func (j *Jenkins) JobGetConfig(jobName string) error {
 	job, err := j.Instance.GetJob(j.Context, jobName)
@@ -144,7 +153,6 @@ func (j *Jenkins) JobGetConfig(jobName string) error {
 // Args:
 //
 // Returns
-//
 func (j *Jenkins) ShowBuildQueue() error {
 	queue, _ := j.Instance.GetQueue(j.Context)
 	totalTasks := 0
@@ -192,9 +200,11 @@ func (j *Jenkins) ShowStatus(object string) {
 // GetLastCompletedBuild get last completed build
 //
 // Args:
+//
 //	jobName - Job Name
 //
 // Returns:
+//
 //	error or nil
 func (j *Jenkins) GetLastCompletedBuild(jobName string) error {
 	fmt.Printf("⏳ Collecting job information...\n")
@@ -220,10 +230,12 @@ func (j *Jenkins) GetLastCompletedBuild(jobName string) error {
 // CreateView will create a view
 //
 // Args:
+//
 //	viewname - view name
 //	viewType - view type
 //
 // Returns
+//
 //	error or nil
 func (j *Jenkins) CreateView(viewName string, viewType string) error {
 	fmt.Printf("%s\n", viewType)
@@ -239,11 +251,13 @@ func (j *Jenkins) CreateView(viewName string, viewType string) error {
 // DownloadArtifacts will download artifacts
 //
 // Args:
+//
 //	jobName - job name
 //	buildID - build ID
 //	pathToSave - path to save artifact
 //
 // Returns:
+//
 //	error or nil
 func (j *Jenkins) DownloadArtifacts(jobName string, buildID int64, pathToSave string) error {
 	job, err := j.Instance.GetJob(j.Context, jobName)
@@ -274,9 +288,11 @@ func (j *Jenkins) DownloadArtifacts(jobName string, buildID int64, pathToSave st
 // GetLastUnstableBuild will get last unstable build
 //
 // Args:
+//
 //	jobName - Job Name
 //
 // Returns:
+//
 //	error or nil
 func (j *Jenkins) GetLastUnstableBuild(jobName string) error {
 	fmt.Printf("⏳ Collecting job information...\n")
@@ -302,9 +318,11 @@ func (j *Jenkins) GetLastUnstableBuild(jobName string) error {
 // GetLastStableBuild will get last stable build
 //
 // Args:
+//
 //	jobName - Job Name
 //
 // Returns:
+//
 //	error or nil
 func (j *Jenkins) GetLastStableBuild(jobName string) error {
 	fmt.Printf("⏳ Collecting job information...\n")
@@ -330,9 +348,11 @@ func (j *Jenkins) GetLastStableBuild(jobName string) error {
 // GetLastBuild will get last build
 //
 // Args:
+//
 //	jobName - Job Name
 //
 // Returns:
+//
 //	error or nil
 func (j *Jenkins) GetLastBuild(jobName string) error {
 	fmt.Printf("⏳ Collecting job information...\n")
@@ -358,9 +378,11 @@ func (j *Jenkins) GetLastBuild(jobName string) error {
 // GetLastFailedBuild will get last failed build
 //
 // Args:
+//
 //	jobName - Job Name
 //
 // Returns:
+//
 //	error or nil
 func (j *Jenkins) GetLastFailedBuild(jobName string) error {
 	fmt.Printf("⏳ Collecting job information...\n")
@@ -398,9 +420,11 @@ func (j *Jenkins) AddJobToView(viewName string, jobName string) error {
 // GetLastSuccessfulBuild will get last failed build
 //
 // Args:
+//
 //	jobName - Job Name
 //
 // Returns:
+//
 //	error or nil
 func (j *Jenkins) GetLastSuccessfulBuild(jobName string) error {
 	fmt.Printf("⏳ Collecting job information...\n")
@@ -427,6 +451,7 @@ func (j *Jenkins) GetLastSuccessfulBuild(jobName string) error {
 // Args:
 //
 // Returns:
+//
 //	error or nil
 func (j *Jenkins) ShowAllJobs() error {
 	jobs, err := j.Instance.GetAllJobs(j.Context)
@@ -448,7 +473,8 @@ func (j *Jenkins) ShowAllJobs() error {
 // Args:
 //
 // Returns:
-// 	error or nil
+//
+//	error or nil
 func (j *Jenkins) ShowViews() error {
 	views, err := j.Instance.GetView(j.Context, "All")
 	if err != nil {
@@ -475,10 +501,12 @@ func getFileAsString(path string) (string, error) {
 // CreateJob will create a job based on XML specification
 //
 // Args:
+//
 //	xmlFile	- Job described in XML format
 //	jobName - Job Name
 //
 // Returns:
+//
 //	error or nil
 func (j *Jenkins) CreateJob(xmlFile string, jobName string) error {
 	jobData, err := getFileAsString(xmlFile)
@@ -493,9 +521,11 @@ func (j *Jenkins) CreateJob(xmlFile string, jobName string) error {
 // ShowNodes show all plugins installed and enabled
 //
 // Args:
+//
 //	showStatus - show only the
 //
 // Returns
+//
 //	code return, nil or error
 func (j *Jenkins) ShowNodes(showStatus string) ([]string, error) {
 	var hosts []string
@@ -535,7 +565,6 @@ func (j *Jenkins) ShowNodes(showStatus string) ([]string, error) {
 // Args:
 //
 // Returns
-//
 func (j *Jenkins) Init(config Config) error {
 	j.JenkinsUser = config.JenkinsUser
 	j.Server = config.Server
@@ -555,7 +584,6 @@ func (j *Jenkins) Init(config Config) error {
 // ServerInfo will show information regarding the server
 //
 // Args:
-//
 func (j *Jenkins) ServerInfo() error {
 	j.Instance.Info(j.Context)
 	fmt.Printf("✅ Connected with: %s\n", j.JenkinsUser)
@@ -569,9 +597,11 @@ func (j *Jenkins) ServerInfo() error {
 // is reachable
 //
 // Args:
+//
 //	string - Jenkins url
 //
 // Returns
+//
 //	nil or error
 func serverReachable(url string) error {
 	_, err := http.Get(url)

--- a/cli/jenkinsctl/jenkinsctl.go
+++ b/cli/jenkinsctl/jenkinsctl.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/credentials.go
+++ b/credentials.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 )
 
-//CredentialsManager is utility to control credential plugin
-//Credentials declared by it can be used in jenkins jobs
+// CredentialsManager is utility to control credential plugin
+// Credentials declared by it can be used in jenkins jobs
 type CredentialsManager struct {
 	J      *Jenkins
 	Folder string
@@ -25,7 +25,7 @@ var listQuery = map[string]string{
 	"tree": "credentials[id]",
 }
 
-//ClassUsernameCredentials is name if java class which implements credentials that store username-password pair
+// ClassUsernameCredentials is name if java class which implements credentials that store username-password pair
 const ClassUsernameCredentials = "com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl"
 
 type credentialID struct {
@@ -36,7 +36,7 @@ type credentialIDs struct {
 	Credentials []credentialID `json:"credentials"`
 }
 
-//UsernameCredentials struct representing credential for storing username-password pair
+// UsernameCredentials struct representing credential for storing username-password pair
 type UsernameCredentials struct {
 	XMLName     xml.Name `xml:"com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl"`
 	ID          string   `xml:"id"`
@@ -46,7 +46,7 @@ type UsernameCredentials struct {
 	Password    string   `xml:"password"`
 }
 
-//StringCredentials store only secret text
+// StringCredentials store only secret text
 type StringCredentials struct {
 	XMLName     xml.Name `xml:"org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl"`
 	ID          string   `xml:"id"`
@@ -55,8 +55,8 @@ type StringCredentials struct {
 	Secret      string   `xml:"secret"`
 }
 
-//FileCredentials store a file
-//"SecretBytes" is a base64 encoded file content
+// FileCredentials store a file
+// "SecretBytes" is a base64 encoded file content
 type FileCredentials struct {
 	XMLName     xml.Name `xml:"org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl"`
 	ID          string   `xml:"id"`
@@ -66,7 +66,7 @@ type FileCredentials struct {
 	SecretBytes string   `xml:"secretBytes"`
 }
 
-//SSHCredentials store credentials for ssh keys.
+// SSHCredentials store credentials for ssh keys.
 type SSHCredentials struct {
 	XMLName          xml.Name    `xml:"com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey"`
 	ID               string      `xml:"id"`
@@ -77,7 +77,7 @@ type SSHCredentials struct {
 	Passphrase       string      `xml:"passphrase,omitempty"`
 }
 
-//DockerServerCredentials store credentials for docker keys.
+// DockerServerCredentials store credentials for docker keys.
 type DockerServerCredentials struct {
 	XMLName             xml.Name `xml:"org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials"`
 	ID                  string   `xml:"id"`
@@ -89,15 +89,15 @@ type DockerServerCredentials struct {
 	ServerCaCertificate string   `xml:"serverCaCertificate"`
 }
 
-//KeySourceDirectEntryType is used when secret in provided directly as private key value
+// KeySourceDirectEntryType is used when secret in provided directly as private key value
 const KeySourceDirectEntryType = "com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$DirectEntryPrivateKeySource"
 
-//KeySourceOnMasterType is used when private key value is path to file on jenkins master
+// KeySourceOnMasterType is used when private key value is path to file on jenkins master
 const KeySourceOnMasterType = "com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$FileOnMasterPrivateKeySource"
 
-//PrivateKey used in SSHCredentials type, type can be either:
-//KeySourceDirectEntryType - then value should be text with secret
-//KeySourceOnMasterType - then value should be path on master jenkins where secret is stored
+// PrivateKey used in SSHCredentials type, type can be either:
+// KeySourceDirectEntryType - then value should be text with secret
+// KeySourceOnMasterType - then value should be path on master jenkins where secret is stored
 type PrivateKey struct {
 	Value string `xml:"privateKey"`
 	Class string `xml:"class,attr"`
@@ -118,7 +118,7 @@ func (cm CredentialsManager) fillURL(url string, params ...interface{}) string {
 	return fmt.Sprintf(url, append(args, params...)...)
 }
 
-//List ids if credentials stored inside provided domain
+// List ids if credentials stored inside provided domain
 func (cm CredentialsManager) List(ctx context.Context, domain string) ([]string, error) {
 
 	idsResponse := credentialIDs{}
@@ -135,8 +135,8 @@ func (cm CredentialsManager) List(ctx context.Context, domain string) ([]string,
 	return ids, nil
 }
 
-//GetSingle searches for credential in given domain with given id, if credential is found
-//it will be parsed as xml to creds parameter(creds must be pointer to struct)
+// GetSingle searches for credential in given domain with given id, if credential is found
+// it will be parsed as xml to creds parameter(creds must be pointer to struct)
 func (cm CredentialsManager) GetSingle(ctx context.Context, domain string, id string, creds interface{}) error {
 	str := ""
 	err := cm.handleResponse(cm.J.Requester.Get(ctx, cm.fillURL(configCredentialURL, domain, id), &str, map[string]string{}))
@@ -147,17 +147,17 @@ func (cm CredentialsManager) GetSingle(ctx context.Context, domain string, id st
 	return xml.Unmarshal([]byte(str), &creds)
 }
 
-//Add credential to given domain, creds must be struct which is parsable to xml
+// Add credential to given domain, creds must be struct which is parsable to xml
 func (cm CredentialsManager) Add(ctx context.Context, domain string, creds interface{}) error {
 	return cm.postCredsXML(ctx, cm.fillURL(createCredentialsURL, domain), creds)
 }
 
-//Delete credential in given domain with given id
+// Delete credential in given domain with given id
 func (cm CredentialsManager) Delete(ctx context.Context, domain string, id string) error {
 	return cm.handleResponse(cm.J.Requester.Post(ctx, cm.fillURL(deleteCredentialURL, domain, id), nil, cm.J.Raw, map[string]string{}))
 }
 
-//Update credential in given domain with given id, creds must be pointer to struct which is parsable to xml
+// Update credential in given domain with given id, creds must be pointer to struct which is parsable to xml
 func (cm CredentialsManager) Update(ctx context.Context, domain string, id string, creds interface{}) error {
 	return cm.postCredsXML(ctx, cm.fillURL(configCredentialURL, domain, id), creds)
 }

--- a/jenkins.go
+++ b/jenkins.go
@@ -505,7 +505,7 @@ func (j *Jenkins) HasPlugin(ctx context.Context, name string) (*Plugin, error) {
 	return p.Contains(name), nil
 }
 
-//InstallPlugin with given version and name
+// InstallPlugin with given version and name
 func (j *Jenkins) InstallPlugin(ctx context.Context, name string, version string) error {
 	xml := fmt.Sprintf(`<jenkins><install plugin="%s@%s" /></jenkins>`, name, version)
 	resp, err := j.Requester.PostXML(ctx, "/pluginManager/installNecessaryPlugins", xml, j.Raw, map[string]string{})
@@ -555,11 +555,13 @@ func (j *Jenkins) GetAllViews(ctx context.Context) ([]*View, error) {
 // First Parameter - name of the View
 // Second parameter - Type
 // Possible Types:
-// 		gojenkins.LIST_VIEW
-// 		gojenkins.NESTED_VIEW
-// 		gojenkins.MY_VIEW
-// 		gojenkins.DASHBOARD_VIEW
-// 		gojenkins.PIPELINE_VIEW
+//
+//	gojenkins.LIST_VIEW
+//	gojenkins.NESTED_VIEW
+//	gojenkins.MY_VIEW
+//	gojenkins.DASHBOARD_VIEW
+//	gojenkins.PIPELINE_VIEW
+//
 // Example: jenkins.CreateView("newView",gojenkins.LIST_VIEW)
 func (j *Jenkins) CreateView(ctx context.Context, name string, viewType string) (*View, error) {
 	view := &View{Jenkins: j, Raw: new(ViewResponse), Base: "/view/" + name}

--- a/job.go
+++ b/job.go
@@ -205,6 +205,23 @@ func (j *Job) GetBuildsFields(ctx context.Context, fields []string, custom inter
 	return nil
 }
 
+func (j *Job) GetBuildsFieldsWithFilter(ctx context.Context, fields []string, fromIndex int, toIndex int, custom interface{}) error {
+	if fields == nil || len(fields) == 0 {
+		return fmt.Errorf("one or more field value needs to be specified")
+	}
+	if fromIndex < 0 || toIndex < 0 {
+		return fmt.Errorf("filter index must be equal to or greater than zero")
+	}
+	// {fromIndex,toIndex} where fromIndex is inclusive and toIndex is exclusive
+	filter := "{" + strconv.Itoa(fromIndex) + "," + strconv.Itoa(toIndex) + "}"
+
+	_, err := j.Jenkins.Requester.GetJSON(ctx, j.Base, &custom, map[string]string{"tree": "builds[" + strings.Join(fields, ",") + "]" + filter})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Returns All Builds with Number and URL
 func (j *Job) GetAllBuildIds(ctx context.Context) ([]JobBuild, error) {
 	var buildsResp struct {

--- a/request.go
+++ b/request.go
@@ -138,7 +138,7 @@ func (r *Requester) SetClient(client *http.Client) *Requester {
 	return r
 }
 
-//Add auth on redirect if required.
+// Add auth on redirect if required.
 func (r *Requester) redirectPolicyFunc(req *http.Request, via []*http.Request) error {
 	if r.BasicAuth != nil {
 		req.SetBasicAuth(r.BasicAuth.Username, r.BasicAuth.Password)


### PR DESCRIPTION
In this PR is included a new method `GetBuildsFieldsWithFilter` on `job.go` which is a copy of `GetBuildsFields` but using the API filters.

> For array-type properties, a range specifier is supported. For example, tree=jobs[name]{0,10} would retrieve the name of the first 10 jobs. The range specifier has the following variants:
> 
> - {M,N}: From the M-th element (inclusive) to the N-th element (exclusive).
> - {M,}: From the M-th element (inclusive) to the end.
> - {,N}: From the first element (inclusive) to the N-th element (exclusive). The same as {0,N}.
> - {N}: Just retrieve the N-th element. The same as {N,N+1}.

I also executed the commands below:

```
go fmt ./...
goimports -l -w .
```
And that's why there are so many small changes, such as import orders, comments, and `godoc` space.