### PR TITLE
the jobUrl end with / and string contact with double /

### DIFF
--- a/job.go
+++ b/job.go
@@ -127,6 +127,9 @@ func (j *Job) GetBuild(ctx context.Context, id int64) (*Build, error) {
 	// "https://<domain>/jenkins/" is the server URL,
 	// we are expecting jobURL = "job/JOB1"
 	jobURL := strings.Replace(j.Raw.URL, j.Jenkins.Server, "", -1)
+	if strings.HasSuffix(jobURL, "/") {
+		jobURL = jobURL[:len(jobURL)-1]
+	}
 	build := Build{Jenkins: j.Jenkins, Job: j, Raw: new(BuildResponse), Depth: 1, Base: jobURL + "/" + strconv.FormatInt(id, 10)}
 	status, err := build.Poll(ctx)
 	if err != nil {


### PR DESCRIPTION
expecting jobURL = "job/JOB1", but I got a jobURL = "job/JOB1/", jobURL ends with "/" and then got a Build URL="job/JOB1//1", request returns 404;
```
if strings.HasSuffix(jobURL, "/") {
	jobURL = jobURL[:len(jobURL)-1]
}
```