### PR TITLE
job.Invoke() correctly passes parameters and files to Jenkins job

### DIFF
--- a/job.go
+++ b/job.go
@@ -468,7 +468,7 @@ func (j *Job) InvokeSimple(ctx context.Context, params map[string]string) (int64
 	return number, nil
 }
 
-func (j *Job) Invoke(ctx context.Context, files []string, skipIfRunning bool, params map[string]string, cause string, securityToken string) (bool, error) {
+func (j *Job) Invoke(ctx context.Context, files map[string]string, skipIfRunning bool, params map[string]string, cause string, securityToken string) (bool, error) {
 	isQueued, err := j.IsQueued(ctx)
 	if err != nil {
 		return false, err
@@ -488,7 +488,7 @@ func (j *Job) Invoke(ctx context.Context, files []string, skipIfRunning bool, pa
 	base := "/build"
 
 	// If parameters are specified - url is /builWithParameters
-	if params != nil {
+	if params != nil || files != nil {
 		base = "/buildWithParameters"
 	} else {
 		params = make(map[string]string)

--- a/job.go
+++ b/job.go
@@ -17,7 +17,6 @@ package gojenkins
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -499,14 +498,16 @@ func (j *Job) Invoke(ctx context.Context, files []string, skipIfRunning bool, pa
 		base = "/build"
 	}
 	reqParams := map[string]string{}
-	buildParams := map[string]string{}
 	if securityToken != "" {
 		reqParams["token"] = securityToken
 	}
 
-	buildParams["json"] = string(makeJson(params))
-	b, _ := json.Marshal(buildParams)
-	resp, err := j.Jenkins.Requester.PostFiles(ctx, j.Base+base, bytes.NewBuffer(b), nil, reqParams, files)
+	data := url.Values{}
+	for k, v := range params {
+		data.Set(k, v)
+	}
+
+	resp, err := j.Jenkins.Requester.PostFiles(ctx, j.Base+base, bytes.NewBufferString(data.Encode()), nil, reqParams, files)
 	if err != nil {
 		return false, err
 	}

--- a/job.go
+++ b/job.go
@@ -17,6 +17,7 @@ package gojenkins
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -493,21 +494,13 @@ func (j *Job) Invoke(ctx context.Context, files []string, skipIfRunning bool, pa
 		params = make(map[string]string)
 	}
 
-	// If files are specified - url is /build
-	if files != nil {
-		base = "/build"
-	}
 	reqParams := map[string]string{}
 	if securityToken != "" {
 		reqParams["token"] = securityToken
 	}
 
-	data := url.Values{}
-	for k, v := range params {
-		data.Set(k, v)
-	}
-
-	resp, err := j.Jenkins.Requester.PostFiles(ctx, j.Base+base, bytes.NewBufferString(data.Encode()), nil, reqParams, files)
+	paramBytes, _ := json.Marshal(params)
+	resp, err := j.Jenkins.Requester.PostFiles(ctx, j.Base+base, bytes.NewBuffer(paramBytes), nil, reqParams, files)
 	if err != nil {
 		return false, err
 	}

--- a/request.go
+++ b/request.go
@@ -99,6 +99,8 @@ func (r *Requester) PostFiles(ctx context.Context, endpoint string, payload io.R
 	if err := r.SetCrumb(ctx, ar); err != nil {
 		return nil, err
 	}
+	ar.SetHeader("Content-Type", "application/x-www-form-urlencoded")
+	ar.Suffix = ""
 	return r.Do(ctx, ar, &responseStruct, querystring, files)
 }
 
@@ -170,8 +172,10 @@ func (r *Requester) Do(ctx context.Context, ar *APIRequest, responseStruct inter
 
 			URL.RawQuery = querystring.Encode()
 		case []string:
-			fileUpload = true
-			files = v
+			if v != nil {
+				fileUpload = true
+				files = v
+			}
 		}
 	}
 	var req *http.Request

--- a/request.go
+++ b/request.go
@@ -94,12 +94,49 @@ func (r *Requester) Post(ctx context.Context, endpoint string, payload io.Reader
 	return r.Do(ctx, ar, &responseStruct, querystring)
 }
 
-func (r *Requester) PostFiles(ctx context.Context, endpoint string, payload io.Reader, responseStruct interface{}, querystring map[string]string, files []string) (*http.Response, error) {
+func (r *Requester) PostFiles(ctx context.Context, endpoint string, payload io.Reader, responseStruct interface{}, querystring map[string]string, files map[string]string) (*http.Response, error) {
 	ar := NewAPIRequest("POST", endpoint, payload)
 	if err := r.SetCrumb(ctx, ar); err != nil {
 		return nil, err
 	}
-	return r.Do(ctx, ar, &responseStruct, querystring, files)
+
+	var err error
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	if files != nil || len(files) != 0 {
+		for fieldname, fileName := range files {
+			fileData, err := os.Open(fileName)
+			if err != nil {
+				Error.Println(err.Error())
+				return nil, err
+			}
+
+			part, err := writer.CreateFormFile(fieldname, filepath.Base(fileName))
+			if err != nil {
+				Error.Println(err.Error())
+				return nil, err
+			}
+			if _, err = io.Copy(part, fileData); err != nil {
+				return nil, err
+			}
+			defer fileData.Close()
+		}
+	}
+
+	var params map[string]string
+	json.NewDecoder(ar.Payload).Decode(&params)
+	for key, val := range params {
+		if err = writer.WriteField(key, val); err != nil {
+			return nil, err
+		}
+	}
+	if err = writer.Close(); err != nil {
+		return nil, err
+	}
+	ar.Payload = body
+	ar.Headers.Add("Content-Type", writer.FormDataContentType())
+
+	return r.Do(ctx, ar, &responseStruct, querystring)
 }
 
 func (r *Requester) PostXML(ctx context.Context, endpoint string, xml string, responseStruct interface{}, querystring map[string]string) (*http.Response, error) {
@@ -146,79 +183,26 @@ func (r *Requester) redirectPolicyFunc(req *http.Request, via []*http.Request) e
 	return nil
 }
 
-func (r *Requester) Do(ctx context.Context, ar *APIRequest, responseStruct interface{}, options ...interface{}) (*http.Response, error) {
+func (r *Requester) Do(ctx context.Context, ar *APIRequest, responseStruct interface{}, options map[string]string) (*http.Response, error) {
 	if !strings.HasSuffix(ar.Endpoint, "/") && ar.Method != "POST" {
 		ar.Endpoint += "/"
 	}
 
-	fileUpload := false
-	var files []string
 	URL, err := url.Parse(r.Base + ar.Endpoint + ar.Suffix)
-
 	if err != nil {
 		return nil, err
 	}
 
-	for _, o := range options {
-		switch v := o.(type) {
-		case map[string]string:
-
-			querystring := make(url.Values)
-			for key, val := range v {
-				querystring.Set(key, val)
-			}
-
-			URL.RawQuery = querystring.Encode()
-		case []string:
-			if v != nil {
-				fileUpload = true
-				files = v
-			}
-		}
+	querystring := make(url.Values)
+	for key, val := range options {
+		querystring.Set(key, val)
 	}
+	URL.RawQuery = querystring.Encode()
+
 	var req *http.Request
-
-	if fileUpload {
-		body := &bytes.Buffer{}
-		writer := multipart.NewWriter(body)
-		for _, file := range files {
-			fileData, err := os.Open(file)
-			if err != nil {
-				Error.Println(err.Error())
-				return nil, err
-			}
-
-			part, err := writer.CreateFormFile("file", filepath.Base(file))
-			if err != nil {
-				Error.Println(err.Error())
-				return nil, err
-			}
-			if _, err = io.Copy(part, fileData); err != nil {
-				return nil, err
-			}
-			defer fileData.Close()
-		}
-		var params map[string]string
-		json.NewDecoder(ar.Payload).Decode(&params)
-		for key, val := range params {
-			if err = writer.WriteField(key, val); err != nil {
-				return nil, err
-			}
-		}
-		if err = writer.Close(); err != nil {
-			return nil, err
-		}
-		req, err = http.NewRequestWithContext(ctx, ar.Method, URL.String(), body)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Content-Type", writer.FormDataContentType())
-	} else {
-
-		req, err = http.NewRequestWithContext(ctx, ar.Method, URL.String(), ar.Payload)
-		if err != nil {
-			return nil, err
-		}
+	req, err = http.NewRequestWithContext(ctx, ar.Method, URL.String(), ar.Payload)
+	if err != nil {
+		return nil, err
 	}
 
 	if r.BasicAuth != nil {

--- a/request.go
+++ b/request.go
@@ -99,8 +99,6 @@ func (r *Requester) PostFiles(ctx context.Context, endpoint string, payload io.R
 	if err := r.SetCrumb(ctx, ar); err != nil {
 		return nil, err
 	}
-	ar.SetHeader("Content-Type", "application/x-www-form-urlencoded")
-	ar.Suffix = ""
 	return r.Do(ctx, ar, &responseStruct, querystring, files)
 }
 


### PR DESCRIPTION
- Code for processing file parameters moved from `r.Do()` to `r.PostFiles()`.
- File parameters now support specifying field name to support cases like :
![image](https://user-images.githubusercontent.com/9055497/229049420-c2f7ff96-27e3-4473-a375-113a062639d4.png)
- `job.Invoke()` returns ID, same as `job.InvokeSimple()`

PR solves https://github.com/bndr/gojenkins/issues/111 and https://github.com/bndr/gojenkins/issues/159

Can you create new release after completing this PR? 
I need this functionality in my project