### PR TITLE
the NodeResponse add field

### DIFF
--- a/node.go
+++ b/node.go
@@ -40,9 +40,12 @@ type NodeResponse struct {
 	DisplayName string        `json:"displayName"`
 	Executors   []struct {
 		CurrentExecutable struct {
-			Number    int    `json:"number"`
-			URL       string `json:"url"`
-			SubBuilds []struct {
+			Number          int    `json:"number"`
+			URL             string `json:"url"`
+			DisplayName     string `json:"displayName"`
+			FullDisplayName string `json:"fullDisplayName"`
+			Timestamp       int64  `json:"timestamp"`
+			SubBuilds       []struct {
 				Abort             bool        `json:"abort"`
 				Build             interface{} `json:"build"`
 				BuildNumber       int         `json:"buildNumber"`


### PR DESCRIPTION
some fields cannot be returned so add fields
```json
{   
  "displayName":"oasis-dev-disguiseadmin #45 (Code: pull source code)",
  "fullDisplayName":"oasis-dev-disguiseadmin #45 (Code: pull source code)",
  "number":45,
  "timestamp":1684304216307,
  "url":"https://devops.5eplaycdn.com/jenkins/job/oasis-dev-disguiseadmin/45/"
}
```