### PR TITLE
Skip JSON decoding when responseStruct is nil

### DIFF
--- a/request.go
+++ b/request.go
@@ -282,6 +282,9 @@ func (r *Requester) ReadRawResponse(response *http.Response, responseStruct inte
 func (r *Requester) ReadJSONResponse(response *http.Response, responseStruct interface{}) (*http.Response, error) {
 	defer func() { _ = response.Body.Close() }()
 
+	if responseStruct == nil {
+		return response, nil
+	}
 	if err := json.NewDecoder(response.Body).Decode(responseStruct); err != nil && err != io.EOF {
 		return response, err
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -213,6 +213,21 @@ func TestReadJSONResponse_ComplexStructure(t *testing.T) {
 	assert.Equal(t, int64(2), result.LastBuild.Number)
 }
 
+func TestReadJSONResponse_NilResponseStruct(t *testing.T) {
+	requester := &Requester{}
+
+	htmlBody := `<!DOCTYPE html><html><body>Jenkins Build Page</body></html>`
+	response := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(bytes.NewBufferString(htmlBody)),
+	}
+
+	resp, err := requester.ReadJSONResponse(response, nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
 func TestRequester_SetClient(t *testing.T) {
 	requester := &Requester{}
 	customClient := &http.Client{}


### PR DESCRIPTION
ReadJSONResponse attempted to decode the response body even when the caller passed nil, meaning no response was expected. This caused errors on endpoints that return non-JSON responses, such as Build.Stop() which receives an HTML page after a redirect.

Fixes #342