### PR TITLE
Skip JSON decode for nil response targets

### DIFF
--- a/request.go
+++ b/request.go
@@ -84,7 +84,7 @@ func (r *Requester) PostJSON(ctx context.Context, endpoint string, payload io.Re
 	}
 	ar.SetHeader("Content-Type", "application/x-www-form-urlencoded")
 	ar.Suffix = "api/json"
-	return r.Do(ctx, ar, &responseStruct, querystring)
+	return r.Do(ctx, ar, jsonResponseTarget(responseStruct), querystring)
 }
 
 // Post sends a POST request with form-urlencoded content type.
@@ -95,7 +95,7 @@ func (r *Requester) Post(ctx context.Context, endpoint string, payload io.Reader
 	}
 	ar.SetHeader("Content-Type", "application/x-www-form-urlencoded")
 	ar.Suffix = ""
-	return r.Do(ctx, ar, &responseStruct, querystring)
+	return r.Do(ctx, ar, jsonResponseTarget(responseStruct), querystring)
 }
 
 // PostFiles sends a POST request with file attachments.
@@ -104,7 +104,7 @@ func (r *Requester) PostFiles(ctx context.Context, endpoint string, payload io.R
 	if err := r.SetCrumb(ctx, ar); err != nil {
 		return nil, err
 	}
-	return r.Do(ctx, ar, &responseStruct, querystring, files)
+	return r.Do(ctx, ar, jsonResponseTarget(responseStruct), querystring, files)
 }
 
 // PostXML sends a POST request with XML content.
@@ -116,7 +116,7 @@ func (r *Requester) PostXML(ctx context.Context, endpoint string, xml string, re
 	}
 	ar.SetHeader("Content-Type", "application/xml;charset=utf-8")
 	ar.Suffix = ""
-	return r.Do(ctx, ar, &responseStruct, querystring)
+	return r.Do(ctx, ar, jsonResponseTarget(responseStruct), querystring)
 }
 
 // GetJSON sends a GET request and expects a JSON response.
@@ -124,7 +124,14 @@ func (r *Requester) GetJSON(ctx context.Context, endpoint string, responseStruct
 	ar := NewAPIRequest("GET", endpoint, nil)
 	ar.SetHeader("Content-Type", "application/json")
 	ar.Suffix = "api/json"
-	return r.Do(ctx, ar, &responseStruct, query)
+	return r.Do(ctx, ar, jsonResponseTarget(responseStruct), query)
+}
+
+func jsonResponseTarget(responseStruct interface{}) interface{} {
+	if responseStruct == nil {
+		return nil
+	}
+	return &responseStruct
 }
 
 // GetXML sends a GET request and expects an XML response.
@@ -282,6 +289,9 @@ func (r *Requester) ReadRawResponse(response *http.Response, responseStruct inte
 func (r *Requester) ReadJSONResponse(response *http.Response, responseStruct interface{}) (*http.Response, error) {
 	defer func() { _ = response.Body.Close() }()
 
+	if responseStruct == nil {
+		return response, nil
+	}
 	if err := json.NewDecoder(response.Body).Decode(responseStruct); err != nil && err != io.EOF {
 		return response, err
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -16,8 +16,10 @@ package gojenkins
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -174,6 +176,35 @@ func TestReadJSONResponse_EmptyBody(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, "", result.Name)
+}
+
+func TestPost_NilResponseSkipsJSONDecode(t *testing.T) {
+	var sawStop bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/job/test-job/1/stop":
+			sawStop = true
+			http.Redirect(w, r, "/job/test-job/1/", http.StatusFound)
+		case "/job/test-job/1/":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>stopping</body></html>"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	requester := &Requester{
+		Base:   server.URL,
+		Client: server.Client(),
+	}
+
+	resp, err := requester.Post(context.Background(), "/job/test-job/1/stop", nil, nil, nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, sawStop)
 }
 
 func TestReadJSONResponse_ComplexStructure(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve nil response targets through requester helpers
- skip JSON decoding when callers intentionally ignore the response body
- cover Jenkins redirect-to-HTML behavior for endpoints like Build.Stop()

Fixes #342

## Verification
- gofmt -w request.go request_test.go
- go test ./...
- review-fix-loop: clean fresh review, no actionable issues