### PR TITLE
Expose choice parameter values

### DIFF
--- a/job.go
+++ b/job.go
@@ -53,9 +53,10 @@ type ParameterDefinition struct {
 		Name  string      `json:"name"`
 		Value interface{} `json:"value"`
 	} `json:"defaultParameterValue"`
-	Description string `json:"description"`
-	Name        string `json:"name"`
-	Type        string `json:"type"`
+	Choices     []string `json:"choices"`
+	Description string   `json:"description"`
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
 }
 
 // JobResponse represents the JSON response from the Jenkins API for a job.

--- a/job_test.go
+++ b/job_test.go
@@ -463,6 +463,42 @@ func TestJob_GetConfig_Error(t *testing.T) {
 	assert.Empty(t, config)
 }
 
+func TestJob_GetParameters_WithChoiceValues(t *testing.T) {
+	jenkins := newMockJenkins()
+	jenkins.Requester.(*MockRequester).GetJSONFunc = func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+		if jr, ok := response.(*JobResponse); ok {
+			jr.Property = []struct {
+				ParameterDefinitions []ParameterDefinition `json:"parameterDefinitions"`
+			}{
+				{
+					ParameterDefinitions: []ParameterDefinition{
+						{
+							Name:        "KIND",
+							Type:        "ChoiceParameterDefinition",
+							Description: "Kind",
+							Choices:     []string{"SBD", "Popcorn (dry)", "Wet", "Juicy"},
+						},
+					},
+				},
+			}
+		}
+		return &http.Response{StatusCode: 200}, nil
+	}
+
+	job := &Job{
+		Jenkins: jenkins,
+		Raw:     &JobResponse{},
+		Base:    "/job/test-job",
+	}
+
+	parameters, err := job.GetParameters(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, parameters, 1)
+	assert.Equal(t, "KIND", parameters[0].Name)
+	assert.Equal(t, []string{"SBD", "Popcorn (dry)", "Wet", "Juicy"}, parameters[0].Choices)
+}
+
 func TestJob_UpdateConfig_Success(t *testing.T) {
 	jenkins := newMockJenkins()
 	var capturedEndpoint string


### PR DESCRIPTION
## Summary

- expose Jenkins choice parameter values through `ParameterDefinition.Choices`
- add focused `GetParameters` coverage for `ChoiceParameterDefinition`

Fixes #223.

This is a minimal refresh of the useful part of stale PR #170, which is now conflicting and includes unrelated vendored/module changes.

## Verification

- `go test ./... -run TestJob_GetParameters_WithChoiceValues`
- `go test ./...`
- `git diff --check`
- `review-fix-loop`: clean
