### PR TITLE
Return crumb request errors

### DIFF
--- a/request.go
+++ b/request.go
@@ -66,7 +66,16 @@ type Requester struct {
 // SetCrumb fetches and sets the CSRF crumb token on the request.
 func (r *Requester) SetCrumb(ctx context.Context, ar *APIRequest) error {
 	crumbData := map[string]string{}
-	response, _ := r.GetJSON(ctx, "/crumbIssuer/api/json", &crumbData, nil)
+	response, err := r.GetJSON(ctx, "/crumbIssuer/api/json", &crumbData, nil)
+	if err != nil && response == nil {
+		return err
+	}
+	if response == nil {
+		return errors.New("crumb issuer response was nil")
+	}
+	if err != nil && response.StatusCode == 200 {
+		return err
+	}
 
 	if response.StatusCode == 200 && crumbData["crumbRequestField"] != "" {
 		ar.SetHeader(crumbData["crumbRequestField"], crumbData["crumb"])

--- a/request.go
+++ b/request.go
@@ -66,7 +66,7 @@ type Requester struct {
 // SetCrumb fetches and sets the CSRF crumb token on the request.
 func (r *Requester) SetCrumb(ctx context.Context, ar *APIRequest) error {
 	crumbData := map[string]string{}
-	response, err := r.GetJSON(ctx, "/crumbIssuer/api/json", &crumbData, nil)
+	response, err := r.GetJSON(ctx, "/crumbIssuer", &crumbData, nil)
 	if err != nil && response == nil {
 		return err
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -16,6 +16,8 @@ package gojenkins
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -23,6 +25,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestNewAPIRequest_Basic(t *testing.T) {
 	ar := NewAPIRequest("GET", "/api/json", nil)
@@ -237,4 +245,87 @@ func TestRequester_Fields(t *testing.T) {
 	assert.Equal(t, "admin", requester.BasicAuth.Username)
 	assert.Equal(t, "password", requester.BasicAuth.Password)
 	assert.True(t, requester.SslVerify)
+}
+
+func TestRequester_SetCrumbReturnsGetJSONError(t *testing.T) {
+	expected := errors.New("crumb request failed")
+	requester := &Requester{
+		Base: "http://jenkins.example",
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return nil, expected
+			}),
+		},
+	}
+	request := NewAPIRequest("POST", "/job/test/build", nil)
+
+	err := requester.SetCrumb(context.Background(), request)
+
+	assert.ErrorIs(t, err, expected)
+}
+
+func TestRequester_SetCrumbIgnoresNonOKResponse(t *testing.T) {
+	requester := &Requester{
+		Base: "http://jenkins.example",
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Header:     http.Header{"Set-Cookie": []string{"crumb-cookie"}},
+					Body:       io.NopCloser(strings.NewReader("<html>not found</html>")),
+				}, nil
+			}),
+		},
+	}
+	request := NewAPIRequest("POST", "/job/test/build", nil)
+
+	err := requester.SetCrumb(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Empty(t, request.Headers.Get("Jenkins-Crumb"))
+	assert.Empty(t, request.Headers.Get("Cookie"))
+}
+
+func TestRequester_SetCrumbReturnsOKDecodeError(t *testing.T) {
+	requester := &Requester{
+		Base: "http://jenkins.example",
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("<html>invalid crumb</html>")),
+				}, nil
+			}),
+		},
+	}
+	request := NewAPIRequest("POST", "/job/test/build", nil)
+
+	err := requester.SetCrumb(context.Background(), request)
+
+	assert.Error(t, err)
+	assert.Empty(t, request.Headers.Get("Jenkins-Crumb"))
+}
+
+func TestRequester_SetCrumbSetsHeadersOnOKResponse(t *testing.T) {
+	requester := &Requester{
+		Base: "http://jenkins.example",
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Set-Cookie": []string{"crumb-cookie"}},
+					Body: io.NopCloser(strings.NewReader(
+						`{"crumbRequestField":"Jenkins-Crumb","crumb":"abc123"}`,
+					)),
+				}, nil
+			}),
+		},
+	}
+	request := NewAPIRequest("POST", "/job/test/build", nil)
+
+	err := requester.SetCrumb(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "abc123", request.Headers.Get("Jenkins-Crumb"))
+	assert.Equal(t, "crumb-cookie", request.Headers.Get("Cookie"))
 }

--- a/request_test.go
+++ b/request_test.go
@@ -311,6 +311,7 @@ func TestRequester_SetCrumbSetsHeadersOnOKResponse(t *testing.T) {
 		Base: "http://jenkins.example",
 		Client: &http.Client{
 			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, "/crumbIssuer/api/json", req.URL.Path)
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     http.Header{"Set-Cookie": []string{"crumb-cookie"}},


### PR DESCRIPTION
Refreshes stale PR #300 with a smaller tested fix for the panic reported there, plus a small follow-up for the crumb issuer endpoint path.

`SetCrumb` previously ignored the `GetJSON` result entirely, which could panic when the crumb request failed before returning an HTTP response. This keeps the existing best-effort behavior for non-OK crumb issuer responses, while returning transport/no-response errors and successful 200 responses that cannot be decoded as JSON.

The follow-up fixes the crumb lookup path. `GetJSON` already appends `/api/json`, so `SetCrumb` should call `/crumbIssuer`; otherwise the request goes to `/crumbIssuer/api/json/api/json` and misses the Jenkins crumb endpoint.

Verification:

- `go test ./... -run 'TestRequester_SetCrumb|TestNewAPIRequest|TestAPIRequest_SetHeader' -count=1 -v`
- `go test ./... -count=1`
- `git diff --check`
