### PR TITLE
Expose node response fields

### DIFF
--- a/node.go
+++ b/node.go
@@ -34,16 +34,26 @@ type Node struct {
 	Base    string
 }
 
+// NodeAssignedLabel represents a label assigned to a Jenkins node.
+type NodeAssignedLabel struct {
+	Name string `json:"name"`
+}
+
 // NodeResponse represents the JSON response from the Jenkins API for a node.
 type NodeResponse struct {
-	Class       string        `json:"_class"`
-	Actions     []interface{} `json:"actions"`
-	DisplayName string        `json:"displayName"`
-	Executors   []struct {
+	Class          string              `json:"_class"`
+	Actions        []interface{}       `json:"actions"`
+	AssignedLabels []NodeAssignedLabel `json:"assignedLabels"`
+	Description    string              `json:"description"`
+	DisplayName    string              `json:"displayName"`
+	Executors      []struct {
 		CurrentExecutable struct {
-			Number    int    `json:"number"`
-			URL       string `json:"url"`
-			SubBuilds []struct {
+			DisplayName     string `json:"displayName"`
+			FullDisplayName string `json:"fullDisplayName"`
+			Number          int    `json:"number"`
+			Timestamp       int64  `json:"timestamp"`
+			URL             string `json:"url"`
+			SubBuilds       []struct {
 				Abort             bool        `json:"abort"`
 				Build             interface{} `json:"build"`
 				BuildNumber       int         `json:"buildNumber"`

--- a/node_test.go
+++ b/node_test.go
@@ -16,6 +16,7 @@ package gojenkins
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -30,6 +31,49 @@ func TestNode_GetName(t *testing.T) {
 	}
 
 	assert.Equal(t, "test-agent", node.GetName())
+}
+
+func TestNodeResponse_UnmarshalAdditionalFields(t *testing.T) {
+	data := []byte(`{
+		"_class": "hudson.slaves.SlaveComputer",
+		"displayName": "agent-1",
+		"description": "macOS build agent",
+		"assignedLabels": [
+			{"name": "agent-1"},
+			{"name": "macos"},
+			{"name": "xcode"}
+		],
+		"executors": [
+			{
+				"currentExecutable": {
+					"displayName": "example-job #45",
+					"fullDisplayName": "folder/example-job #45",
+					"number": 45,
+					"timestamp": 1684304216307,
+					"url": "https://jenkins.example/job/folder/job/example-job/45/"
+				}
+			}
+		]
+	}`)
+	var response NodeResponse
+
+	err := json.Unmarshal(data, &response)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "agent-1", response.DisplayName)
+	assert.Equal(t, "macOS build agent", response.Description)
+	assert.Equal(t, []NodeAssignedLabel{
+		{Name: "agent-1"},
+		{Name: "macos"},
+		{Name: "xcode"},
+	}, response.AssignedLabels)
+	assert.Len(t, response.Executors, 1)
+	executable := response.Executors[0].CurrentExecutable
+	assert.Equal(t, "example-job #45", executable.DisplayName)
+	assert.Equal(t, "folder/example-job #45", executable.FullDisplayName)
+	assert.Equal(t, 45, executable.Number)
+	assert.Equal(t, int64(1684304216307), executable.Timestamp)
+	assert.Equal(t, "https://jenkins.example/job/folder/job/example-job/45/", executable.URL)
 }
 
 func TestNode_IsOnline_True(t *testing.T) {


### PR DESCRIPTION
Refreshes the stale node-response field requests from #307, #309, and #324.

This exposes additional fields Jenkins already returns from node/computer JSON:
- node `description`
- node `assignedLabels` as typed label names
- current executable `displayName`, `fullDisplayName`, and `timestamp`

The regression test uses representative Jenkins JSON for `assignedLabels: [{"name": "..."}]`, addressing the earlier maintainer request on #309 for a real assigned-label example.

Verification:
- `go test ./... -run 'TestNodeResponse_UnmarshalAdditionalFields|TestJenkins_GetAllNodes|TestJenkins_GetNode|TestNode_GetName'`
- `go test ./...`
- `git diff --check`
- `review-fix-loop`: no actionable defects
