### PR TITLE
Support CopyJob folder paths

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -560,7 +560,7 @@ func (j *Jenkins) GetAllViews(ctx context.Context) ([]*View, error) {
 	return views, nil
 }
 
-func (j *Jenkins) DeleteView(ctx context.Context, name string) (error) {
+func (j *Jenkins) DeleteView(ctx context.Context, name string) error {
 	endpoint := fmt.Sprintf("/view/%s/doDelete", name)
 	r, err := j.Requester.Post(ctx, endpoint, nil, nil, nil)
 
@@ -573,7 +573,6 @@ func (j *Jenkins) DeleteView(ctx context.Context, name string) (error) {
 	}
 	return errors.New(strconv.Itoa(r.StatusCode))
 }
-
 
 // Create View
 // First Parameter - name of the View

--- a/jenkins.go
+++ b/jenkins.go
@@ -250,7 +250,7 @@ func (j *Jenkins) RenameJob(ctx context.Context, job string, name string) *Job {
 // Create a copy of a job.
 // First parameter Name of the job to copy from, Second parameter new job name.
 func (j *Jenkins) CopyJob(ctx context.Context, copyFrom string, newName string) (*Job, error) {
-	job := Job{Jenkins: j, Raw: new(JobResponse), Base: "/job/" + copyFrom}
+	job := Job{Jenkins: j, Raw: new(JobResponse), Base: jobBaseFromFullName(copyFrom)}
 	_, err := job.Poll(ctx)
 	if err != nil {
 		return nil, err

--- a/jenkins_unit_test.go
+++ b/jenkins_unit_test.go
@@ -16,6 +16,7 @@ package gojenkins
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"testing"
 
@@ -172,6 +173,50 @@ func TestJenkins_GetJob_NestedJob(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, job)
 	assert.Equal(t, "/job/parent-folder/job/nested-job", job.Base)
+}
+
+func TestJenkins_CopyJob_WithFolderPaths(t *testing.T) {
+	getEndpoints := []string{}
+	var capturedEndpoint string
+	var capturedQuery map[string]string
+	mock := &MockRequester{
+		GetJSONFunc: func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+			getEndpoints = append(getEndpoints, endpoint)
+			if jr, ok := response.(*JobResponse); ok {
+				switch endpoint {
+				case "/job/source-folder/job/source-job":
+					jr.Name = "source-job"
+					jr.FullName = "source-folder/source-job"
+				case "/job/dest-folder/job/copied-job":
+					jr.Name = "copied-job"
+					jr.FullName = "dest-folder/copied-job"
+				}
+			}
+			return &http.Response{StatusCode: 200}, nil
+		},
+		PostFunc: func(ctx context.Context, endpoint string, payload io.Reader, response interface{}, query map[string]string) (*http.Response, error) {
+			capturedEndpoint = endpoint
+			capturedQuery = query
+			return &http.Response{StatusCode: 200}, nil
+		},
+	}
+
+	jenkins := &Jenkins{
+		Server:    "http://jenkins.local",
+		Requester: mock,
+	}
+
+	job, err := jenkins.CopyJob(context.Background(), "/source-folder/source-job", "/dest-folder/copied-job")
+	assert.NoError(t, err)
+	assert.NotNil(t, job)
+	assert.Equal(t, []string{"/job/source-folder/job/source-job", "/job/dest-folder/job/copied-job"}, getEndpoints)
+	assert.Equal(t, "/job/dest-folder/createItem", capturedEndpoint)
+	assert.Equal(t, map[string]string{
+		"name": "copied-job",
+		"from": "source-folder/source-job",
+		"mode": "copy",
+	}, capturedQuery)
+	assert.Equal(t, "/job/dest-folder/job/copied-job", job.Base)
 }
 
 func TestJenkins_GetBuild_Success(t *testing.T) {

--- a/job.go
+++ b/job.go
@@ -107,6 +107,62 @@ func (j *Job) parentBase() string {
 	return j.Base[:strings.LastIndex(j.Base, "/job/")]
 }
 
+func normalizeJobFullName(name string) string {
+	name = strings.Trim(name, "/")
+	parts := strings.Split(name, "/")
+	cleaned := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			cleaned = append(cleaned, part)
+		}
+	}
+	return strings.Join(cleaned, "/")
+}
+
+func jobBaseFromFullName(name string) string {
+	name = normalizeJobFullName(name)
+	if name == "" {
+		return ""
+	}
+	return "/job/" + strings.Join(strings.Split(name, "/"), "/job/")
+}
+
+func jobFullNameFromBase(base string) string {
+	base = strings.Trim(base, "/")
+	if base == "" {
+		return ""
+	}
+
+	parts := strings.Split(base, "/")
+	names := make([]string, 0, len(parts)/2)
+	for i := 0; i < len(parts); i += 2 {
+		if parts[i] != "job" || i+1 >= len(parts) {
+			return ""
+		}
+		names = append(names, parts[i+1])
+	}
+	return strings.Join(names, "/")
+}
+
+func splitJobParentAndName(fullName string) (string, string) {
+	fullName = normalizeJobFullName(fullName)
+	idx := strings.LastIndex(fullName, "/")
+	if idx == -1 {
+		return "", fullName
+	}
+	return fullName[:idx], fullName[idx+1:]
+}
+
+func (j *Job) copySourceFullName() string {
+	if j.Raw != nil && j.Raw.FullName != "" {
+		return normalizeJobFullName(j.Raw.FullName)
+	}
+	if fullName := jobFullNameFromBase(j.Base); fullName != "" {
+		return fullName
+	}
+	return normalizeJobFullName(j.GetName())
+}
+
 // History represents a build history entry with status and timestamp information.
 type History struct {
 	BuildDisplayName string
@@ -371,13 +427,15 @@ func (j *Job) Create(ctx context.Context, config string, qr ...interface{}) (*Jo
 
 // Copy creates a copy of the job with the specified destination name.
 func (j *Job) Copy(ctx context.Context, destinationName string) (*Job, error) {
-	qr := map[string]string{"name": destinationName, "from": j.GetName(), "mode": "copy"}
-	resp, err := j.Jenkins.Requester.Post(ctx, j.parentBase()+"/createItem", nil, nil, qr)
+	destinationFullName := normalizeJobFullName(destinationName)
+	destinationParent, destinationLeaf := splitJobParentAndName(destinationFullName)
+	qr := map[string]string{"name": destinationLeaf, "from": j.copySourceFullName(), "mode": "copy"}
+	resp, err := j.Jenkins.Requester.Post(ctx, jobBaseFromFullName(destinationParent)+"/createItem", nil, nil, qr)
 	if err != nil {
 		return nil, err
 	}
 	if resp.StatusCode == 200 {
-		newJob := &Job{Jenkins: j.Jenkins, Raw: new(JobResponse), Base: "/job/" + destinationName}
+		newJob := &Job{Jenkins: j.Jenkins, Raw: new(JobResponse), Base: jobBaseFromFullName(destinationFullName)}
 		_, err := newJob.Poll(ctx)
 		if err != nil {
 			return nil, err

--- a/job_test.go
+++ b/job_test.go
@@ -16,6 +16,7 @@ package gojenkins
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"testing"
 
@@ -498,6 +499,73 @@ func TestJob_UpdateConfig_Error(t *testing.T) {
 
 	err := job.UpdateConfig(context.Background(), "<config/>")
 	assert.Error(t, err)
+}
+
+func TestJob_Copy_ToFolderDestination(t *testing.T) {
+	jenkins := newMockJenkins()
+	var capturedEndpoint string
+	var capturedQuery map[string]string
+	var pollEndpoint string
+	jenkins.Requester.(*MockRequester).PostFunc = func(ctx context.Context, endpoint string, payload io.Reader, response interface{}, query map[string]string) (*http.Response, error) {
+		capturedEndpoint = endpoint
+		capturedQuery = query
+		return &http.Response{StatusCode: 200}, nil
+	}
+	jenkins.Requester.(*MockRequester).GetJSONFunc = func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+		pollEndpoint = endpoint
+		return &http.Response{StatusCode: 200}, nil
+	}
+
+	job := &Job{
+		Jenkins: jenkins,
+		Raw: &JobResponse{
+			Name:     "source-job",
+			FullName: "source-folder/source-job",
+		},
+		Base: "/job/source-folder/job/source-job",
+	}
+
+	copied, err := job.Copy(context.Background(), "/dest-folder/copied-job")
+	assert.NoError(t, err)
+	assert.NotNil(t, copied)
+	assert.Equal(t, "/job/dest-folder/createItem", capturedEndpoint)
+	assert.Equal(t, map[string]string{
+		"name": "copied-job",
+		"from": "source-folder/source-job",
+		"mode": "copy",
+	}, capturedQuery)
+	assert.Equal(t, "/job/dest-folder/job/copied-job", copied.Base)
+	assert.Equal(t, "/job/dest-folder/job/copied-job", pollEndpoint)
+}
+
+func TestJob_Copy_UsesBaseForNestedSourceWithoutFullName(t *testing.T) {
+	jenkins := newMockJenkins()
+	var capturedEndpoint string
+	var capturedQuery map[string]string
+	jenkins.Requester.(*MockRequester).PostFunc = func(ctx context.Context, endpoint string, payload io.Reader, response interface{}, query map[string]string) (*http.Response, error) {
+		capturedEndpoint = endpoint
+		capturedQuery = query
+		return &http.Response{StatusCode: 200}, nil
+	}
+
+	job := &Job{
+		Jenkins: jenkins,
+		Raw: &JobResponse{
+			Name: "source-job",
+		},
+		Base: "/job/source-folder/job/source-job",
+	}
+
+	copied, err := job.Copy(context.Background(), "copied-job")
+	assert.NoError(t, err)
+	assert.NotNil(t, copied)
+	assert.Equal(t, "/createItem", capturedEndpoint)
+	assert.Equal(t, map[string]string{
+		"name": "copied-job",
+		"from": "source-folder/source-job",
+		"mode": "copy",
+	}, capturedQuery)
+	assert.Equal(t, "/job/copied-job", copied.Base)
 }
 
 func TestJob_InvokeSimple_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

- Normalize slash-separated job full names for `CopyJob` so folder paths map to Jenkins `/job/...` URLs.
- Copy from the source job full name and create the destination job under the destination folder with only the leaf name.
- Add unit coverage for both the public `Jenkins.CopyJob` wrapper and lower-level `Job.Copy` folder handling.

This refreshes the still-open folder-copy request in #201 as a minimal tested change.

## Tests

- `go test . -run 'Test(Job_Copy|Jenkins_CopyJob)'`
- `go test ./...`
- `git diff --check`
- `review-fix-loop`: no actionable correctness issues
