### PR TITLE
Add GetUser API

### DIFF
--- a/users.go
+++ b/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -17,6 +18,15 @@ type User struct {
 	UserName string
 	FullName string
 	Email    string
+}
+
+type userResponse struct {
+	ID       string `json:"id"`
+	FullName string `json:"fullName"`
+	Property []struct {
+		Class   string `json:"_class"`
+		Address string `json:"address"`
+	} `json:"property"`
 }
 
 // ErrUser occurs when there is error creating or revoking Jenkins users
@@ -48,6 +58,40 @@ func (j *Jenkins) CreateUser(ctx context.Context, userName, password, fullName, 
 		}
 	}
 	return user, nil
+}
+
+// GetUser fetches a Jenkins account by username.
+func (j *Jenkins) GetUser(ctx context.Context, userName string) (User, error) {
+	user := User{
+		Jenkins:  j,
+		UserName: userName,
+	}
+	raw := userResponse{}
+	response, err := j.Requester.GetJSON(ctx, "/user/"+url.PathEscape(userName), &raw, nil)
+	if err != nil {
+		return user, err
+	}
+	if response.StatusCode != http.StatusOK {
+		return user, &ErrUser{
+			Message: fmt.Sprintf("error getting user. Status is %d", response.StatusCode),
+		}
+	}
+
+	if raw.ID != "" {
+		user.UserName = raw.ID
+	}
+	user.FullName = raw.FullName
+	user.Email = raw.email()
+	return user, nil
+}
+
+func (r *userResponse) email() string {
+	for _, property := range r.Property {
+		if property.Class == "hudson.tasks.Mailer$UserProperty" {
+			return property.Address
+		}
+	}
+	return ""
 }
 
 // DeleteUser deletes a Jenkins account

--- a/users_test.go
+++ b/users_test.go
@@ -77,6 +77,118 @@ func TestCreateUserNetworkError(t *testing.T) {
 	assert.Contains(t, err.Error(), "connection refused")
 }
 
+// TestGetUserSuccess tests successful user retrieval
+func TestGetUserSuccess(t *testing.T) {
+	mock := &MockRequester{
+		GetJSONFunc: func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+			user, ok := response.(*userResponse)
+			assert.True(t, ok)
+			user.ID = "testuser"
+			user.FullName = "Test User"
+			user.Property = append(user.Property, struct {
+				Class   string `json:"_class"`
+				Address string `json:"address"`
+			}{
+				Class:   "hudson.tasks.Mailer$UserProperty",
+				Address: "test@example.com",
+			})
+			return &http.Response{StatusCode: http.StatusOK}, nil
+		},
+	}
+
+	jenkins := &Jenkins{
+		Server:    "http://jenkins.local",
+		Requester: mock,
+	}
+
+	user, err := jenkins.GetUser(context.Background(), "testuser")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "testuser", user.UserName)
+	assert.Equal(t, "Test User", user.FullName)
+	assert.Equal(t, "test@example.com", user.Email)
+	assert.Equal(t, jenkins, user.Jenkins)
+	assert.Equal(t, "/user/testuser", mock.lastEndpoint)
+}
+
+// TestGetUserEscapesUsername tests that user IDs are escaped in the API path
+func TestGetUserEscapesUsername(t *testing.T) {
+	mock := &MockRequester{
+		response: &http.Response{StatusCode: http.StatusOK},
+	}
+
+	jenkins := &Jenkins{
+		Server:    "http://jenkins.local",
+		Requester: mock,
+	}
+
+	_, err := jenkins.GetUser(context.Background(), "folder/user")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "/user/folder%2Fuser", mock.lastEndpoint)
+}
+
+// TestGetUserWithoutEmail tests successful user retrieval without a Mailer property
+func TestGetUserWithoutEmail(t *testing.T) {
+	mock := &MockRequester{
+		GetJSONFunc: func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+			user, ok := response.(*userResponse)
+			assert.True(t, ok)
+			user.ID = "noemail"
+			user.FullName = "No Email"
+			return &http.Response{StatusCode: http.StatusOK}, nil
+		},
+	}
+
+	jenkins := &Jenkins{
+		Server:    "http://jenkins.local",
+		Requester: mock,
+	}
+
+	user, err := jenkins.GetUser(context.Background(), "noemail")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "noemail", user.UserName)
+	assert.Equal(t, "No Email", user.FullName)
+	assert.Empty(t, user.Email)
+}
+
+// TestGetUserError tests user retrieval with HTTP error
+func TestGetUserError(t *testing.T) {
+	mock := &MockRequester{
+		response: &http.Response{StatusCode: http.StatusNotFound},
+	}
+
+	jenkins := &Jenkins{
+		Server:    "http://jenkins.local",
+		Requester: mock,
+	}
+
+	_, err := jenkins.GetUser(context.Background(), "missing")
+
+	assert.Error(t, err)
+	errUser, ok := err.(*ErrUser)
+	assert.True(t, ok)
+	assert.Contains(t, errUser.Message, "404")
+}
+
+// TestGetUserNetworkError tests user retrieval with network error
+func TestGetUserNetworkError(t *testing.T) {
+	mock := &MockRequester{
+		err: errors.New("connection refused"),
+	}
+
+	jenkins := &Jenkins{
+		Server:    "http://jenkins.local",
+		Requester: mock,
+	}
+
+	_, err := jenkins.GetUser(context.Background(), "testuser")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
 // TestDeleteUserSuccess tests successful user deletion
 func TestDeleteUserSuccess(t *testing.T) {
 	mock := &MockRequester{


### PR DESCRIPTION
## Summary

- Add a minimal library-level `GetUser(ctx, userName)` API for fetching Jenkins users.
- Map Jenkins user JSON into the existing `User` type, including Mailer email when Jenkins exposes it.
- Add focused unit coverage for success, escaped user IDs, missing email, HTTP errors, and requester errors.

Fixes #310.

This refreshes the `GetUser` part of stale PR #313 without pulling in the broader `GetAllUsers`/module/CLI changes.

## Tests

- `go test . -run 'Test(GetUser|CreateUser|DeleteUser|UserDelete|ErrUser)'`
- `go test ./...`
- `go test -count=1 ./...`
- `git diff --check`
