### PR TITLE
Add Groovy script execution

### DIFF
--- a/jenkins_unit_test.go
+++ b/jenkins_unit_test.go
@@ -16,7 +16,9 @@ package gojenkins
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -553,4 +555,48 @@ func TestJenkins_SafeRestart_Success(t *testing.T) {
 
 	err := jenkins.SafeRestart(context.Background())
 	assert.NoError(t, err)
+}
+
+func TestJenkins_ExecuteScript_Success(t *testing.T) {
+	mock := &MockRequester{
+		PostFunc: func(ctx context.Context, endpoint string, payload io.Reader, response interface{}, query map[string]string) (*http.Response, error) {
+			assert.Equal(t, "/scriptText", endpoint)
+			assert.Nil(t, query)
+
+			body, err := io.ReadAll(payload)
+			assert.NoError(t, err)
+
+			values, err := url.ParseQuery(string(body))
+			assert.NoError(t, err)
+			assert.Equal(t, `println("Hello World!")`, values.Get("script"))
+
+			output, ok := response.(*string)
+			if assert.True(t, ok) {
+				*output = "Hello World!\n"
+			}
+
+			return &http.Response{StatusCode: 200}, nil
+		},
+	}
+
+	jenkins := &Jenkins{
+		Server:    "http://jenkins.local",
+		Requester: mock,
+	}
+
+	output, err := jenkins.ExecuteScript(context.Background(), `println("Hello World!")`)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello World!\n", output)
+}
+
+func TestJenkins_ExecuteScript_Error(t *testing.T) {
+	mock := &MockRequester{err: assert.AnError}
+	jenkins := &Jenkins{
+		Server:    "http://jenkins.local",
+		Requester: mock,
+	}
+
+	output, err := jenkins.ExecuteScript(context.Background(), `println("Hello World!")`)
+	assert.Equal(t, assert.AnError, err)
+	assert.Empty(t, output)
 }

--- a/request.go
+++ b/request.go
@@ -95,6 +95,9 @@ func (r *Requester) Post(ctx context.Context, endpoint string, payload io.Reader
 	}
 	ar.SetHeader("Content-Type", "application/x-www-form-urlencoded")
 	ar.Suffix = ""
+	if _, ok := responseStruct.(*string); ok {
+		return r.Do(ctx, ar, responseStruct, querystring)
+	}
 	return r.Do(ctx, ar, &responseStruct, querystring)
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -16,8 +16,11 @@ package gojenkins
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -211,6 +214,47 @@ func TestReadJSONResponse_ComplexStructure(t *testing.T) {
 	assert.Len(t, result.Builds, 2)
 	assert.Equal(t, int64(1), result.Builds[0].Number)
 	assert.Equal(t, int64(2), result.LastBuild.Number)
+}
+
+func TestRequesterPostReadsRawStringResponse(t *testing.T) {
+	var form url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/crumbIssuer") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("{}"))
+			return
+		}
+
+		assert.Equal(t, "/scriptText", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+
+		form, err = url.ParseQuery(string(body))
+		assert.NoError(t, err)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("plain output\n"))
+	}))
+	defer server.Close()
+
+	requester := &Requester{
+		Base:   server.URL,
+		Client: server.Client(),
+	}
+
+	values := url.Values{}
+	values.Set("script", `println("Hello World!")`)
+
+	var output string
+	_, err := requester.Post(context.Background(), "/scriptText", strings.NewReader(values.Encode()), &output, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "plain output\n", output)
+	assert.Equal(t, `println("Hello World!")`, form.Get("script"))
 }
 
 func TestRequester_SetClient(t *testing.T) {

--- a/script.go
+++ b/script.go
@@ -1,0 +1,34 @@
+// Copyright 2015 Vadim Kravcenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package gojenkins
+
+import (
+	"context"
+	"net/url"
+	"strings"
+)
+
+// ExecuteScript runs a Groovy script through Jenkins' script console endpoint.
+func (j *Jenkins) ExecuteScript(ctx context.Context, script string) (string, error) {
+	data := url.Values{}
+	data.Set("script", script)
+
+	var output string
+	_, err := j.Requester.Post(ctx, "/scriptText", strings.NewReader(data.Encode()), &output, nil)
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}


### PR DESCRIPTION
## Summary

- add `Jenkins.ExecuteScript(ctx, script)` for Jenkins' `/scriptText` Groovy script console endpoint
- submit the `script` parameter as form-urlencoded request body data
- read the endpoint's plain text response when `Requester.Post` is called with a `*string` response target

Fixes #55.

This is a current-`master` refresh of the same feature direction as stale PR #240.

## Verification

```text
go test . -run 'TestJenkins_ExecuteScript|TestRequesterPostReadsRawStringResponse' -count=1 -v
go test ./... -count=1
gofmt -l script.go jenkins_unit_test.go request.go request_test.go
git diff --check origin/master...HEAD
```
