### PR TITLE
Fix GetBuild URLs for Jenkins context paths

### DIFF
--- a/job.go
+++ b/job.go
@@ -133,12 +133,15 @@ func (j *Job) GetDetails() *JobResponse {
 // GetBuild retrieves a specific build by its build number.
 func (j *Job) GetBuild(ctx context.Context, id int64) (*Build, error) {
 
-	// Support customized server URL,
-	// i.e. Server : https://<domain>/jenkins/job/JOB1
-	// "https://<domain>/jenkins/" is the server URL,
-	// we are expecting jobURL = "job/JOB1"
-	jobURL := strings.ReplaceAll(j.Raw.URL, j.Jenkins.Server, "")
-	build := Build{Jenkins: j.Jenkins, Job: j, Raw: new(BuildResponse), Depth: 1, Base: jobURL + "/" + strconv.FormatInt(id, 10)}
+	// Support Jenkins instances served from a context path.
+	jobURL := strings.TrimPrefix(j.Raw.URL, strings.TrimRight(j.Jenkins.Server, "/"))
+	if jobURL == j.Raw.URL {
+		jobURL = j.Base
+	}
+	jobURL = "/" + strings.Trim(jobURL, "/")
+	buildBase := strings.TrimRight(jobURL, "/") + "/" + strconv.FormatInt(id, 10)
+
+	build := Build{Jenkins: j.Jenkins, Job: j, Raw: new(BuildResponse), Depth: 1, Base: buildBase}
 	status, err := build.Poll(ctx)
 	if err != nil {
 		return nil, err

--- a/job_test.go
+++ b/job_test.go
@@ -580,7 +580,8 @@ func TestJob_InvokeSimple_AlreadyQueued(t *testing.T) {
 
 func TestJob_GetBuild_Success(t *testing.T) {
 	jenkins := newMockJenkins()
-	jenkins.Requester.(*MockRequester).GetJSONFunc = func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+	mock := jenkins.Requester.(*MockRequester)
+	mock.GetJSONFunc = func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
 		if br, ok := response.(*BuildResponse); ok {
 			br.Number = 42
 			br.Result = "SUCCESS"
@@ -602,6 +603,63 @@ func TestJob_GetBuild_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, build)
 	assert.Equal(t, int64(42), build.GetBuildNumber())
+	assert.Equal(t, "/job/test-job/42", mock.lastEndpoint)
+}
+
+func TestJob_GetBuild_WithJenkinsContextPath(t *testing.T) {
+	jenkins := newMockJenkins()
+	mock := jenkins.Requester.(*MockRequester)
+	mock.GetJSONFunc = func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+		if br, ok := response.(*BuildResponse); ok {
+			br.Number = 42
+			br.Result = "SUCCESS"
+			br.URL = "http://localhost:8080/jenkins/job/test-job/42/"
+		}
+		return &http.Response{StatusCode: 200}, nil
+	}
+
+	job := &Job{
+		Jenkins: jenkins,
+		Raw: &JobResponse{
+			URL: "http://localhost:8080/jenkins/job/test-job/",
+		},
+		Base: "/job/test-job",
+	}
+	jenkins.Server = "http://localhost:8080/jenkins"
+
+	build, err := job.GetBuild(context.Background(), 42)
+	assert.NoError(t, err)
+	assert.NotNil(t, build)
+	assert.Equal(t, int64(42), build.GetBuildNumber())
+	assert.Equal(t, "/job/test-job/42", mock.lastEndpoint)
+}
+
+func TestJob_GetBuild_FallsBackToJobBase(t *testing.T) {
+	jenkins := newMockJenkins()
+	mock := jenkins.Requester.(*MockRequester)
+	mock.GetJSONFunc = func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+		if br, ok := response.(*BuildResponse); ok {
+			br.Number = 42
+			br.Result = "SUCCESS"
+			br.URL = "http://jenkins.example.com/job/test-job/42/"
+		}
+		return &http.Response{StatusCode: 200}, nil
+	}
+
+	job := &Job{
+		Jenkins: jenkins,
+		Raw: &JobResponse{
+			URL: "http://jenkins.example.com/job/test-job/",
+		},
+		Base: "/job/test-job",
+	}
+	jenkins.Server = "http://localhost:8080/"
+
+	build, err := job.GetBuild(context.Background(), 42)
+	assert.NoError(t, err)
+	assert.NotNil(t, build)
+	assert.Equal(t, int64(42), build.GetBuildNumber())
+	assert.Equal(t, "/job/test-job/42", mock.lastEndpoint)
 }
 
 func TestJob_GetBuild_NotFound(t *testing.T) {


### PR DESCRIPTION
Summary:
- normalize `Job.GetBuild` base paths when Jenkins is served from a context path such as `/jenkins`
- avoid the double slash in build endpoints when `JobResponse.URL` has a trailing slash
- add regression coverage for context-path URLs and the existing job-base fallback

Fixes #316.
Fixes #304.
Fixes #121.
Fixes #176.
Fixes #258.

Verification:
- `go test . -run 'TestJob_GetBuild' -count=1 -v`
- `go test ./... -count=1`
- `gofmt -l job.go job_test.go`
- `git diff --check origin/master...HEAD`
