### PR TITLE
Fix nested Folder.Create endpoint

### DIFF
--- a/folder.go
+++ b/folder.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"strconv"
-	"strings"
 )
 
 // Folder represents a Jenkins folder that can contain jobs and other folders.
@@ -40,9 +39,11 @@ type FolderResponse struct {
 	Views       []ViewData `json:"views"`
 }
 
-// parentBase returns the base URL of the parent folder.
-func (f *Folder) parentBase() string {
-	return f.Base[:strings.LastIndex(f.Base, "/job")]
+func (f *Folder) childBase(name string) string {
+	if f.Base == "" {
+		return "/job/" + name
+	}
+	return f.Base + "/job/" + name
 }
 
 // GetName returns the name of the folder.
@@ -62,13 +63,14 @@ func (f *Folder) Create(ctx context.Context, name string) (*Folder, error) {
 			"mode": mode,
 		}),
 	}
-	r, err := f.Jenkins.Requester.Post(ctx, f.parentBase()+"/createItem", nil, f.Raw, data)
+	folder := &Folder{Jenkins: f.Jenkins, Raw: new(FolderResponse), Base: f.childBase(name)}
+	r, err := f.Jenkins.Requester.Post(ctx, f.Base+"/createItem", nil, folder.Raw, data)
 	if err != nil {
 		return nil, err
 	}
 	if r.StatusCode == 200 {
-		_, _ = f.Poll(ctx)
-		return f, nil
+		_, _ = folder.Poll(ctx)
+		return folder, nil
 	}
 	return nil, errors.New(strconv.Itoa(r.StatusCode))
 }

--- a/folder_test.go
+++ b/folder_test.go
@@ -16,6 +16,7 @@ package gojenkins
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"testing"
 
@@ -40,39 +41,6 @@ func TestFolder_GetName_Empty(t *testing.T) {
 	}
 
 	assert.Equal(t, "", folder.GetName())
-}
-
-func TestFolder_parentBase(t *testing.T) {
-	tests := []struct {
-		name     string
-		base     string
-		expected string
-	}{
-		{
-			name:     "root folder",
-			base:     "/job/my-folder",
-			expected: "",
-		},
-		{
-			name:     "nested folder",
-			base:     "/job/parent/job/child",
-			expected: "/job/parent",
-		},
-		{
-			name:     "deeply nested folder",
-			base:     "/job/level1/job/level2/job/level3",
-			expected: "/job/level1/job/level2",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			folder := &Folder{
-				Base: tt.base,
-			}
-			assert.Equal(t, tt.expected, folder.parentBase())
-		})
-	}
 }
 
 func TestFolder_Poll_Success(t *testing.T) {
@@ -108,34 +76,108 @@ func TestFolder_Poll_Error(t *testing.T) {
 
 func TestFolder_Create_Success(t *testing.T) {
 	jenkins := newMockJenkins()
-	jenkins.Requester.(*MockRequester).response = &http.Response{
-		StatusCode: 200,
+	requester := jenkins.Requester.(*MockRequester)
+	var postEndpoint string
+	var pollEndpoint string
+	requester.PostFunc = func(ctx context.Context, endpoint string, payload io.Reader, response interface{}, query map[string]string) (*http.Response, error) {
+		postEndpoint = endpoint
+		assert.IsType(t, &FolderResponse{}, response)
+		assert.Equal(t, "child-folder", query["name"])
+		return &http.Response{StatusCode: 200}, nil
+	}
+	requester.GetJSONFunc = func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+		pollEndpoint = endpoint
+		return &http.Response{StatusCode: 200}, nil
 	}
 
 	folder := &Folder{
 		Jenkins: jenkins,
 		Raw:     &FolderResponse{},
-		Base:    "/job/parent/job/new-folder",
+		Base:    "/job/parent/job/current-folder",
 	}
 
-	result, err := folder.Create(context.Background(), "new-folder")
+	result, err := folder.Create(context.Background(), "child-folder")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
+	assert.Equal(t, "/job/parent/job/current-folder/job/child-folder", result.Base)
+	assert.Equal(t, "/job/parent/job/current-folder/createItem", postEndpoint)
+	assert.Equal(t, result.Base, pollEndpoint)
+}
+
+func TestFolder_Create_RootFolder(t *testing.T) {
+	jenkins := newMockJenkins()
+	requester := jenkins.Requester.(*MockRequester)
+	var postEndpoint string
+	var pollEndpoint string
+	requester.PostFunc = func(ctx context.Context, endpoint string, payload io.Reader, response interface{}, query map[string]string) (*http.Response, error) {
+		postEndpoint = endpoint
+		return &http.Response{StatusCode: 200}, nil
+	}
+	requester.GetJSONFunc = func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+		pollEndpoint = endpoint
+		return &http.Response{StatusCode: 200}, nil
+	}
+
+	folder := &Folder{
+		Jenkins: jenkins,
+		Raw:     &FolderResponse{},
+		Base:    "",
+	}
+
+	result, err := folder.Create(context.Background(), "child-folder")
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "/job/child-folder", result.Base)
+	assert.Equal(t, "/createItem", postEndpoint)
+	assert.Equal(t, result.Base, pollEndpoint)
+}
+
+func TestJenkins_CreateFolder_NestedParents(t *testing.T) {
+	jenkins := newMockJenkins()
+	requester := jenkins.Requester.(*MockRequester)
+	var postEndpoint string
+	var pollEndpoint string
+	requester.PostFunc = func(ctx context.Context, endpoint string, payload io.Reader, response interface{}, query map[string]string) (*http.Response, error) {
+		postEndpoint = endpoint
+		assert.Equal(t, "child-folder", query["name"])
+		return &http.Response{StatusCode: 200}, nil
+	}
+	requester.GetJSONFunc = func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+		pollEndpoint = endpoint
+		return &http.Response{StatusCode: 200}, nil
+	}
+
+	result, err := jenkins.CreateFolder(context.Background(), "child-folder", "parent", "current-folder")
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "/job/parent/job/current-folder/job/child-folder", result.Base)
+	assert.Equal(t, "/job/parent/job/current-folder/createItem", postEndpoint)
+	assert.Equal(t, result.Base, pollEndpoint)
 }
 
 func TestFolder_Create_Failure(t *testing.T) {
 	jenkins := newMockJenkins()
-	jenkins.Requester.(*MockRequester).response = &http.Response{
-		StatusCode: 400,
+	requester := jenkins.Requester.(*MockRequester)
+	var postEndpoint string
+	var pollEndpoint string
+	requester.PostFunc = func(ctx context.Context, endpoint string, payload io.Reader, response interface{}, query map[string]string) (*http.Response, error) {
+		postEndpoint = endpoint
+		return &http.Response{StatusCode: 400}, nil
+	}
+	requester.GetJSONFunc = func(ctx context.Context, endpoint string, response interface{}, query map[string]string) (*http.Response, error) {
+		pollEndpoint = endpoint
+		return &http.Response{StatusCode: 200}, nil
 	}
 
 	folder := &Folder{
 		Jenkins: jenkins,
 		Raw:     &FolderResponse{},
-		Base:    "/job/parent/job/new-folder",
+		Base:    "/job/parent/job/current-folder",
 	}
 
-	result, err := folder.Create(context.Background(), "new-folder")
+	result, err := folder.Create(context.Background(), "child-folder")
 	assert.Error(t, err)
 	assert.Nil(t, result)
+	assert.Equal(t, "/job/parent/job/current-folder/createItem", postEndpoint)
+	assert.Equal(t, "", pollEndpoint)
 }

--- a/jenkins.go
+++ b/jenkins.go
@@ -190,7 +190,12 @@ func (j *Jenkins) DeleteNode(ctx context.Context, name string) (bool, error) {
 // This folder can be nested in other parent folders
 // Example: jenkins.CreateFolder("newFolder", "grandparentFolder", "parentFolder")
 func (j *Jenkins) CreateFolder(ctx context.Context, name string, parents ...string) (*Folder, error) {
-	folderObj := &Folder{Jenkins: j, Raw: new(FolderResponse), Base: "/job/" + strings.Join(append(parents, name), "/job/")}
+	base := ""
+	if len(parents) > 0 {
+		base = "/job/" + strings.Join(parents, "/job/")
+	}
+
+	folderObj := &Folder{Jenkins: j, Raw: new(FolderResponse), Base: base}
 	folder, err := folderObj.Create(ctx, name)
 	if err != nil {
 		return nil, err
@@ -560,7 +565,7 @@ func (j *Jenkins) GetAllViews(ctx context.Context) ([]*View, error) {
 	return views, nil
 }
 
-func (j *Jenkins) DeleteView(ctx context.Context, name string) (error) {
+func (j *Jenkins) DeleteView(ctx context.Context, name string) error {
 	endpoint := fmt.Sprintf("/view/%s/doDelete", name)
 	r, err := j.Requester.Post(ctx, endpoint, nil, nil, nil)
 
@@ -573,7 +578,6 @@ func (j *Jenkins) DeleteView(ctx context.Context, name string) (error) {
 	}
 	return errors.New(strconv.Itoa(r.StatusCode))
 }
-
 
 // Create View
 // First Parameter - name of the View


### PR DESCRIPTION
Fixes #202.

## Summary
- make `Folder.Create` post to the receiver folder's `createItem` endpoint
- return and poll the newly created child folder instead of the parent folder
- keep `Jenkins.CreateFolder` behavior by delegating from the parent folder path

## Verification
- `go test ./... -run 'TestFolder_Create|TestJenkins_CreateFolder_NestedParents' -count=1`
- `go test ./... -count=1`
- `gofmt -l folder.go jenkins.go folder_test.go`
- `git diff --check`
